### PR TITLE
Split MetricRouter and MetricAggregator

### DIFF
--- a/internal/metricAggregator/README.md
+++ b/internal/metricAggregator/README.md
@@ -1,0 +1,38 @@
+# The MetricAggregator
+
+In some cases, further combination of metrics or raw values is required. For that strings like `foo + 1` with runtime dependent `foo` need to be evaluated. The MetricAggregator relies on the [`gval`](https://github.com/PaesslerAG/gval) Golang package to perform all expression evaluation. The `gval` package provides the basic arithmetic operations but the MetricAggregator defines additional ones.
+
+**Note**: To get an impression which expressions can be handled by `gval`, see its [README](https://github.com/PaesslerAG/gval/blob/master/README.md)
+
+## Simple expression evaluation
+
+For simple expression evaluation, the MetricAggregator provides two function for different use-cases:
+- `EvalBoolCondition(expression string, params map[string]interface{}`: Used by the MetricRouter to match metrics like `metric.Name() == 'mymetric'`
+- `EvalFloat64Condition(expression string, params map[string]interface{})`: Used by the MetricRouter and LikwidCollector to derive new values like `(PMC0+PMC1)/PMC3`
+
+## MetricAggregator extensions for `gval`
+
+The MetricAggregator provides these functions additional to the `Full` language in `gval`:
+- `sum(array)`: Sum up values in an array like `sum(values)`
+- `min(array)`: Get the minimum value in an array like `min(values)`
+- `avg(array)`: Get the mean value in an array like `avg(values)`
+- `mean(array)`: Get the mean value in an array like `mean(values)`
+- `max(array)`: Get the maximum value in an array like `max(values)`
+- `len(array)`: Get the length of an array like `len(values)`
+- `median(array)`: Get the median value in an array like `mean(values)`
+- `in`: Check existence in an array like `0 in getCpuList()` to check whether there is an entry `0`. Also substring matching works like `temp in metric.Name()`
+- `match`: Regular-expression matching like `match('temp_cores_%d+', metric.Name())`. **Note** all `\` in an regex has to be replaced with `%`
+- `getCpuCore(cpuid)`: For a CPU id, the the corresponding CPU core id like `getCpuCore(0)`
+- `getCpuSocket(cpuid)`: For a CPU id, the the corresponding CPU socket id
+- `getCpuNuma(cpuid)`: For a CPU id, the the corresponding NUMA domain id
+- `getCpuDie(cpuid)`: For a CPU id, the the corresponding CPU die id
+- `getSockCpuList(sockid)`: For a given CPU socket id, the list of CPU ids is returned like the CPUs on socket 1 `getSockCpuList(1)`
+- `getNumaCpuList(numaid)`: For a given NUMA node id, the list of CPU ids is returned
+- `getDieCpuList(dieid)`: For a given CPU die id, the list of CPU ids is returned
+- `getCoreCpuList(coreid)`: For a given CPU core id, the list of CPU ids is returned
+- `getCpuList`: Get the list of all CPUs
+
+## Limitations
+
+- Since the metrics are written in JSON files which do not allow `""` without proper escaping inside of JSON strings, you have to use `''` for strings.
+- Since `\` is interpreted by JSON as escape character, it cannot be used in metrics. But it is required to write regular expressions. So instead of `/`, use `%` and the MetricAggregator replaces them after reading the JSON file.

--- a/internal/metricAggregator/metricAggregator.go
+++ b/internal/metricAggregator/metricAggregator.go
@@ -1,4 +1,4 @@
-package metricRouter
+package metricAggregator
 
 import (
 	"context"
@@ -16,7 +16,7 @@ import (
 	"github.com/PaesslerAG/gval"
 )
 
-type metricAggregatorIntervalConfig struct {
+type MetricAggregatorIntervalConfig struct {
 	Name      string            `json:"name"`     // Metric name for the new metric
 	Function  string            `json:"function"` // Function to apply on the metric
 	Condition string            `json:"if"`       // Condition for applying function
@@ -27,7 +27,7 @@ type metricAggregatorIntervalConfig struct {
 }
 
 type metricAggregator struct {
-	functions []*metricAggregatorIntervalConfig
+	functions []*MetricAggregatorIntervalConfig
 	constants map[string]interface{}
 	language  gval.Language
 	output    chan lp.CCMetric
@@ -65,7 +65,7 @@ var metricCacheLanguage = gval.NewLanguage(
 
 func (c *metricAggregator) Init(output chan lp.CCMetric) error {
 	c.output = output
-	c.functions = make([]*metricAggregatorIntervalConfig, 0)
+	c.functions = make([]*MetricAggregatorIntervalConfig, 0)
 	c.constants = make(map[string]interface{})
 
 	// add constants like hostname, numSockets, ... to constants list
@@ -246,7 +246,7 @@ func (c *metricAggregator) AddAggregation(name, function, condition string, tags
 			return nil
 		}
 	}
-	var agg metricAggregatorIntervalConfig
+	var agg MetricAggregatorIntervalConfig
 	agg.Name = name
 	agg.Condition = newcond
 	agg.gvalCond = gvalCond

--- a/internal/metricAggregator/metricAggregatorFunctions.go
+++ b/internal/metricAggregator/metricAggregatorFunctions.go
@@ -1,4 +1,4 @@
-package metricRouter
+package metricAggregator
 
 import (
 	"errors"

--- a/internal/metricRouter/metricCache.go
+++ b/internal/metricRouter/metricCache.go
@@ -7,6 +7,7 @@ import (
 	cclog "github.com/ClusterCockpit/cc-metric-collector/internal/ccLogger"
 
 	lp "github.com/ClusterCockpit/cc-metric-collector/internal/ccMetric"
+	agg "github.com/ClusterCockpit/cc-metric-collector/internal/metricAggregator"
 	mct "github.com/ClusterCockpit/cc-metric-collector/internal/multiChanTicker"
 )
 
@@ -28,7 +29,7 @@ type metricCache struct {
 	tickchan   chan time.Time
 	done       chan bool
 	output     chan lp.CCMetric
-	aggEngine  MetricAggregator
+	aggEngine  agg.MetricAggregator
 }
 
 type MetricCache interface {
@@ -59,7 +60,7 @@ func (c *metricCache) Init(output chan lp.CCMetric, ticker mct.MultiChanTicker, 
 
 	// Create a new aggregation engine. No separate goroutine at the moment
 	// The code is executed by the MetricCache goroutine
-	c.aggEngine, err = NewAggregator(c.output)
+	c.aggEngine, err = agg.NewAggregator(c.output)
 	if err != nil {
 		cclog.ComponentError("MetricCache", "Cannot create aggregator")
 		return err


### PR DESCRIPTION
The MetricAggregator is also used by the LikwidCollector to derive the metrics, so now it's an own package. Also all [`gval`](https://github.com/PaesslerAG/gval) related code is contained in that package