### PR TITLE
Automatically flush batched writes in the HTTP sink

### DIFF
--- a/sinks/httpSink.go
+++ b/sinks/httpSink.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
+	cclog "github.com/ClusterCockpit/cc-metric-collector/internal/ccLogger"
 	lp "github.com/ClusterCockpit/cc-metric-collector/internal/ccMetric"
 	influx "github.com/influxdata/line-protocol"
 )
@@ -19,19 +21,21 @@ type HttpSinkConfig struct {
 	Timeout         string `json:"timeout,omitempty"`
 	MaxIdleConns    int    `json:"max_idle_connections,omitempty"`
 	IdleConnTimeout string `json:"idle_connection_timeout,omitempty"`
-	BatchSize       int    `json:"batch_size,omitempty"`
+	FlushDelay      string `json:"flush_delay,omitempty"`
 }
 
 type HttpSink struct {
 	sink
 	client          *http.Client
 	encoder         *influx.Encoder
+	lock            sync.Mutex // Flush() runs in another goroutine, so this lock has to protect the buffer
 	buffer          *bytes.Buffer
+	flushTimer      *time.Timer
 	config          HttpSinkConfig
 	maxIdleConns    int
 	idleConnTimeout time.Duration
 	timeout         time.Duration
-	batchCounter    int
+	flushDelay      time.Duration
 }
 
 func (s *HttpSink) Init(config json.RawMessage) error {
@@ -40,10 +44,7 @@ func (s *HttpSink) Init(config json.RawMessage) error {
 	s.config.MaxIdleConns = 10
 	s.config.IdleConnTimeout = "5s"
 	s.config.Timeout = "5s"
-	s.config.BatchSize = 20
-
-	// Reset counter
-	s.batchCounter = 0
+	s.config.FlushDelay = "1s"
 
 	// Read config
 	if len(config) > 0 {
@@ -70,6 +71,12 @@ func (s *HttpSink) Init(config json.RawMessage) error {
 			s.timeout = t
 		}
 	}
+	if len(s.config.FlushDelay) > 0 {
+		t, err := time.ParseDuration(s.config.FlushDelay)
+		if err == nil {
+			s.flushDelay = t
+		}
+	}
 	tr := &http.Transport{
 		MaxIdleConns:    s.maxIdleConns,
 		IdleConnTimeout: s.idleConnTimeout,
@@ -83,25 +90,47 @@ func (s *HttpSink) Init(config json.RawMessage) error {
 }
 
 func (s *HttpSink) Write(m lp.CCMetric) error {
-	p := m.ToPoint(s.config.MetaAsTags)
-	_, err := s.encoder.Encode(p)
+	if s.buffer.Len() == 0 && s.flushDelay != 0 {
+		// This is the first write since the last flush, start the flushTimer!
+		if s.flushTimer != nil && s.flushTimer.Stop() {
+			cclog.ComponentDebug("HttpSink", "unexpected: the flushTimer was already running?")
+		}
 
-	// Flush when received more metrics than batch size
-	s.batchCounter++
-	if s.batchCounter > s.config.BatchSize {
-		s.Flush()
+		// Run a batched flush for all lines that have arrived in the last second
+		s.flushTimer = time.AfterFunc(s.flushDelay, func() {
+			if err := s.Flush(); err != nil {
+				cclog.ComponentError("HttpSink", "flush failed:", err.Error())
+			}
+		})
 	}
+
+	p := m.ToPoint(s.config.MetaAsTags)
+
+	s.lock.Lock()
+	_, err := s.encoder.Encode(p)
+	s.lock.Unlock() // defer does not work here as Flush() takes the lock as well
+
+	if err != nil {
+		return err
+	}
+
+	// Flush synchronously if "flush_delay" is zero
+	if s.flushDelay == 0 {
+		return s.Flush()
+	}
+
 	return err
 }
 
 func (s *HttpSink) Flush() error {
+	// buffer is read by client.Do, prevent concurrent modifications
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
 	// Do not flush empty buffer
-	if s.batchCounter == 0 {
+	if s.buffer.Len() == 0 {
 		return nil
 	}
-
-	// Reset counter
-	s.batchCounter = 0
 
 	// Create new request to send buffer
 	req, err := http.NewRequest(http.MethodPost, s.config.URL, s.buffer)
@@ -120,12 +149,12 @@ func (s *HttpSink) Flush() error {
 	// Clear buffer
 	s.buffer.Reset()
 
-	// Handle error code
+	// Handle transport/tcp errors
 	if err != nil {
 		return err
 	}
 
-	// Handle status code
+	// Handle application errors
 	if res.StatusCode != http.StatusOK {
 		return errors.New(res.Status)
 	}
@@ -134,6 +163,9 @@ func (s *HttpSink) Flush() error {
 }
 
 func (s *HttpSink) Close() {
-	s.Flush()
+	s.flushTimer.Stop()
+	if err := s.Flush(); err != nil {
+		cclog.ComponentError("HttpSink", "flush failed:", err.Error())
+	}
 	s.client.CloseIdleConnections()
 }

--- a/sinks/httpSink.md
+++ b/sinks/httpSink.md
@@ -9,25 +9,21 @@ The `http` sink uses POST requests to a HTTP server to submit the metrics in the
   "<name>": {
     "type": "http",
     "meta_as_tags" : true,
-    "database" : "mymetrics",
-    "host": "dbhost.example.com",
-    "port": "4222",
-    "jwt" : "0x0000q231",
-    "ssl" : false,
+    "url" : "https://my-monitoring.example.com:1234/api/write",
+    "jwt" : "blabla.blabla.blabla",
     "timeout": "5s",
     "max_idle_connections" : 10,
-    "idle_connection_timeout" : "5s"
+    "idle_connection_timeout" : "5s",
+    "flush_delay": "2s",
   }
 }
 ```
 
 - `type`: makes the sink an `http` sink
 - `meta_as_tags`: print all meta information as tags in the output (optional)
-- `database`: All metrics are written to this bucket 
-- `host`: Hostname of the InfluxDB database server
-- `port`: Portnumber (as string) of the InfluxDB database server
-- `jwt`: JSON web tokens for authentification
-- `ssl`: Activate SSL encryption
+- `url`: The full URL of the endpoint
+- `jwt`: JSON web tokens for authentification (Using the *Bearer* scheme)
 - `timeout`: General timeout for the HTTP client (default '5s')
 - `max_idle_connections`: Maximally idle connections (default 10)
 - `idle_connection_timeout`: Timeout for idle connections (default '5s')
+- `flush_delay`: Batch all writes arriving in during this duration (default '1s', batching can be disabled by setting it to 0)

--- a/sinks/sinkManager.go
+++ b/sinks/sinkManager.go
@@ -133,7 +133,7 @@ func (sm *sinkManager) AddOutput(name string, rawConfig json.RawMessage) error {
 		}
 	}
 	if _, found := AvailableSinks[sinkConfig.Type]; !found {
-		cclog.ComponentError("SinkManager", "SKIP", name, "unknown sink:", err.Error())
+		cclog.ComponentError("SinkManager", "SKIP", name, "unknown sink:", sinkConfig.Type)
 		return err
 	}
 	s := AvailableSinks[sinkConfig.Type]

--- a/sinks/sinkManager.go
+++ b/sinks/sinkManager.go
@@ -106,7 +106,9 @@ func (sm *sinkManager) Start() {
 				// Send received metric to all outputs
 				cclog.ComponentDebug("SinkManager", "WRITE", p)
 				for _, s := range sm.sinks {
-					s.Write(p)
+					if err := s.Write(p); err != nil {
+						cclog.ComponentError("SinkManager", "WRITE", s.Name(), "write failed:", err.Error())
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The cc-metric-store optimizes for big batches of metrics from the same host. A fixed batch size has the additional problem that writes might be delayed by a full metric collection cycle. This new way of flushing the HTTP sink enables big batches and at the same time sending the data to the cc-metric-store with only a few seconds of delay.

The config file format for the HTTP sink is also simplified.

The NATS.io Sink (also supported by the cc-metric-store) might benefit from something similar, but as NATS.io is a protocol/service I do not know as well, I can not say if it does not already do something like that behind the scenes.