### PR TITLE
Dynamically load liblikwid

### DIFF
--- a/collectors/likwidMetric.go
+++ b/collectors/likwidMetric.go
@@ -94,7 +94,7 @@ type LikwidCollectorConfig struct {
 	Eventsets      []LikwidCollectorEventsetConfig `json:"eventsets"`
 	Metrics        []LikwidCollectorMetricConfig   `json:"globalmetrics,omitempty"`
 	ForceOverwrite bool                            `json:"force_overwrite,omitempty"`
-	NanToZero      bool                            `json:"nan_to_zero,omitempty"`
+	InvalidToZero  bool                            `json:"invalid_to_zero,omitempty"`
 }
 
 type LikwidCollector struct {
@@ -449,7 +449,10 @@ func (m *LikwidCollector) calcEventsetMetrics(group int, interval time.Duration,
 					continue
 				}
 				m.mresults[group][tid][metric.Name] = value
-				if m.config.NanToZero && math.IsNaN(value) {
+				if m.config.InvalidToZero && math.IsNaN(value) {
+					value = 0.0
+				}
+				if m.config.InvalidToZero && math.IsInf(value, 0) {
 					value = 0.0
 				}
 				// Now we have the result, send it with the proper tags
@@ -493,7 +496,10 @@ func (m *LikwidCollector) calcGlobalMetrics(interval time.Duration, output chan 
 					continue
 				}
 				m.gmresults[tid][metric.Name] = value
-				if m.config.NanToZero && math.IsNaN(value) {
+				if m.config.InvalidToZero && math.IsNaN(value) {
+					value = 0.0
+				}
+				if m.config.InvalidToZero && math.IsInf(value, 0) {
 					value = 0.0
 				}
 				// Now we have the result, send it with the proper tags

--- a/collectors/likwidMetric.go
+++ b/collectors/likwidMetric.go
@@ -384,15 +384,13 @@ func (m *LikwidCollector) takeMeasurement(group int, interval time.Duration) err
 	ret = C.perfmon_setupCounters(gid)
 	if ret != 0 {
 		gctr := C.GoString(C.perfmon_getGroupName(gid))
-		err := fmt.Errorf("failed to setup performance group %s", gctr)
-		cclog.ComponentError(m.name, err.Error())
+		err := fmt.Errorf("failed to setup performance group %d (%s)", gid, gctr)
 		return err
 	}
 	ret = C.perfmon_startCounters()
 	if ret != 0 {
 		gctr := C.GoString(C.perfmon_getGroupName(gid))
-		err := fmt.Errorf("failed to start performance group %s", gctr)
-		cclog.ComponentError(m.name, err.Error())
+		err := fmt.Errorf("failed to start performance group %d (%s)", gid, gctr)
 		return err
 	}
 	m.running = true
@@ -401,8 +399,7 @@ func (m *LikwidCollector) takeMeasurement(group int, interval time.Duration) err
 	ret = C.perfmon_stopCounters()
 	if ret != 0 {
 		gctr := C.GoString(C.perfmon_getGroupName(gid))
-		err := fmt.Errorf("failed to stop performance group %s", gctr)
-		cclog.ComponentError(m.name, err.Error())
+		err := fmt.Errorf("failed to stop performance group %d (%s)", gid, gctr)
 		return err
 	}
 	return nil
@@ -533,7 +530,7 @@ func (m *LikwidCollector) Read(interval time.Duration, output chan lp.CCMetric) 
 		err := m.takeMeasurement(i, interval)
 		if err != nil {
 			cclog.ComponentError(m.name, err.Error())
-			continue
+			return
 		}
 		// read measurements and derive event set metrics
 		m.calcEventsetMetrics(i, interval, output)

--- a/collectors/likwidMetric.md
+++ b/collectors/likwidMetric.md
@@ -9,7 +9,7 @@ The `likwid` configuration consists of two parts, the "eventsets" and "globalmet
 
 Additional options:
 - `force_overwrite`: Same as setting `LIKWID_FORCE=1`. In case counters are already in-use, LIKWID overwrites their configuration to do its measurements
-- `nan_to_zero`: In some cases, the calculations result in `NaN`. With this option, all `NaN` values are replaces with `0.0`.
+- `invalid_to_zero`: In some cases, the calculations result in `NaN` or `Inf`. With this option, all `NaN` and `Inf` values are replaces with `0.0`.
 
 ### Available metric scopes
 


### PR DESCRIPTION
- Uses the same flags as the `NvidiaCollector`: `-Wl,--unresolved-symbols=ignore-in-object-files`
- Generalize `nan_to_zero` configuration option to `invalid_to_zero`. All derived metric results being `NaN` or `+/-Inf` are set to `0.0`