### PR TITLE
Use Ganglia configuration

### DIFF
--- a/sinks/gangliaCommon.go
+++ b/sinks/gangliaCommon.go
@@ -155,12 +155,38 @@ func GetCommonGangliaConfig(point lp.CCMetric) GangliaMetricConfig {
 	for _, group := range CommonGangliaMetrics {
 		for _, metric := range group.Metrics {
 			if metric.Name == mname {
+				valueStr := ""
+				value, ok := point.GetField("value")
+				if ok {
+					switch real := value.(type) {
+					case float64:
+						valueStr = fmt.Sprintf("%f", real)
+					case float32:
+						valueStr = fmt.Sprintf("%f", real)
+					case int64:
+						valueStr = fmt.Sprintf("%d", real)
+					case int32:
+						valueStr = fmt.Sprintf("%d", real)
+					case int:
+						valueStr = fmt.Sprintf("%d", real)
+					case uint64:
+						valueStr = fmt.Sprintf("%d", real)
+					case uint32:
+						valueStr = fmt.Sprintf("%d", real)
+					case uint:
+						valueStr = fmt.Sprintf("%d", real)
+					case string:
+						valueStr = real
+					default:
+					}
+				}
 				return GangliaMetricConfig{
 					Group: group.Name,
 					Type:  metric.Type,
 					Slope: metric.Slope,
 					Tmax:  metric.Tmax,
 					Unit:  metric.Unit,
+					Value: valueStr,
 				}
 			}
 		}

--- a/sinks/gangliaCommon.go
+++ b/sinks/gangliaCommon.go
@@ -1,6 +1,7 @@
 package sinks
 
 import (
+	"fmt"
 	"strings"
 
 	lp "github.com/ClusterCockpit/cc-metric-collector/internal/ccMetric"
@@ -23,11 +24,8 @@ func GangliaMetricName(point lp.CCMetric) string {
 	return name
 }
 
-func GangliaMetricRename(point lp.CCMetric) string {
-	name := point.Name()
-	if name == "mem_total" || name == "swap_total" {
-		return name
-	} else if name == "net_bytes_in" {
+func GangliaMetricRename(name string) string {
+	if name == "net_bytes_in" {
 		return "bytes_in"
 	} else if name == "net_bytes_out" {
 		return "bytes_out"
@@ -47,4 +45,188 @@ func GangliaSlopeType(point lp.CCMetric) uint {
 		return 0
 	}
 	return 3
+}
+
+const DEFAULT_GANGLIA_METRIC_TMAX = 300
+const DEFAULT_GANGLIA_METRIC_SLOPE = "both"
+
+type GangliaMetric struct {
+	Name  string
+	Type  string
+	Slope string
+	Tmax  int
+	Unit  string
+}
+
+type GangliaMetricGroup struct {
+	Name    string
+	Metrics []GangliaMetric
+}
+
+var CommonGangliaMetrics = []GangliaMetricGroup{
+	{
+		Name: "memory",
+		Metrics: []GangliaMetric{
+			{"mem_total", "float", "zero", 1200, "KB"},
+			{"swap_total", "float", "zero", 1200, "KB"},
+			{"mem_free", "float", "both", 180, "KB"},
+			{"mem_shared", "float", "both", 180, "KB"},
+			{"mem_buffers", "float", "both", 180, "KB"},
+			{"mem_cached", "float", "both", 180, "KB"},
+			{"swap_free", "float", "both", 180, "KB"},
+			{"mem_sreclaimable", "float", "both", 180, "KB"},
+			{"mem_slab", "float", "both", 180, "KB"},
+		},
+	},
+	{
+		Name: "cpu",
+		Metrics: []GangliaMetric{
+			{"cpu_num", "uint32", "zero", 1200, "CPUs"},
+			{"cpu_speed", "uint32", "zero", 1200, "MHz"},
+			{"cpu_user", "float", "both", 90, "%"},
+			{"cpu_nice", "float", "both", 90, "%"},
+			{"cpu_system", "float", "both", 90, "%"},
+			{"cpu_idle", "float", "both", 3800, "%"},
+			{"cpu_aidle", "float", "both", 90, "%"},
+			{"cpu_wio", "float", "both", 90, "%"},
+			{"cpu_intr", "float", "both", 90, "%"},
+			{"cpu_sintr", "float", "both", 90, "%"},
+			{"cpu_steal", "float", "both", 90, "%"},
+			{"cpu_guest", "float", "both", 90, "%"},
+			{"cpu_gnice", "float", "both", 90, "%"},
+		},
+	},
+	{
+		Name: "load",
+		Metrics: []GangliaMetric{
+			{"load_one", "float", "both", 70, ""},
+			{"load_five", "float", "both", 325, ""},
+			{"load_fifteen", "float", "both", 950, ""},
+		},
+	},
+	{
+		Name: "disk",
+		Metrics: []GangliaMetric{
+			{"disk_total", "double", "both", 1200, "GB"},
+			{"disk_free", "double", "both", 180, "GB"},
+			{"part_max_used", "float", "both", 180, "%"},
+		},
+	},
+	{
+		Name: "network",
+		Metrics: []GangliaMetric{
+			{"bytes_out", "float", "both", 300, "bytes/sec"},
+			{"bytes_in", "float", "both", 300, "bytes/sec"},
+			{"pkts_in", "float", "both", 300, "packets/sec"},
+			{"pkts_out", "float", "both", 300, "packets/sec"},
+		},
+	},
+	{
+		Name: "process",
+		Metrics: []GangliaMetric{
+			{"proc_run", "uint32", "both", 950, ""},
+			{"proc_total", "uint32", "both", 950, ""},
+		},
+	},
+	{
+		Name: "system",
+		Metrics: []GangliaMetric{
+			{"boottime", "uint32", "zero", 1200, "s"},
+			{"sys_clock", "uint32", "zero", 1200, "s"},
+			{"machine_type", "string", "zero", 1200, ""},
+			{"os_name", "string", "zero", 1200, ""},
+			{"os_release", "string", "zero", 1200, ""},
+			{"mtu", "uint32", "both", 1200, ""},
+		},
+	},
+}
+
+type GangliaMetricConfig struct {
+	Type  string
+	Slope string
+	Tmax  int
+	Unit  string
+	Group string
+	Value string
+}
+
+func GetCommonGangliaConfig(point lp.CCMetric) GangliaMetricConfig {
+	mname := GangliaMetricRename(point.Name())
+	for _, group := range CommonGangliaMetrics {
+		for _, metric := range group.Metrics {
+			if metric.Name == mname {
+				return GangliaMetricConfig{
+					Group: group.Name,
+					Type:  metric.Type,
+					Slope: metric.Slope,
+					Tmax:  metric.Tmax,
+					Unit:  metric.Unit,
+				}
+			}
+		}
+	}
+	return GangliaMetricConfig{
+		Group: "",
+		Type:  "",
+		Slope: "",
+		Tmax:  0,
+		Unit:  "",
+		Value: "",
+	}
+}
+
+func GetGangliaConfig(point lp.CCMetric) GangliaMetricConfig {
+	group := ""
+	if g, ok := point.GetMeta("group"); ok {
+		group = g
+	}
+	unit := ""
+	if u, ok := point.GetMeta("unit"); ok {
+		unit = u
+	}
+	valueType := "double"
+	valueStr := ""
+	value, ok := point.GetField("value")
+	if ok {
+		switch real := value.(type) {
+		case float64:
+			valueStr = fmt.Sprintf("%f", real)
+			valueType = "double"
+		case float32:
+			valueStr = fmt.Sprintf("%f", real)
+			valueType = "float"
+		case int64:
+			valueStr = fmt.Sprintf("%d", real)
+			valueType = "int32"
+		case int32:
+			valueStr = fmt.Sprintf("%d", real)
+			valueType = "int32"
+		case int:
+			valueStr = fmt.Sprintf("%d", real)
+			valueType = "int32"
+		case uint64:
+			valueStr = fmt.Sprintf("%d", real)
+			valueType = "uint32"
+		case uint32:
+			valueStr = fmt.Sprintf("%d", real)
+			valueType = "uint32"
+		case uint:
+			valueStr = fmt.Sprintf("%d", real)
+			valueType = "uint32"
+		case string:
+			valueStr = real
+			valueType = "string"
+		default:
+			valueType = "invalid"
+		}
+	}
+
+	return GangliaMetricConfig{
+		Group: group,
+		Type:  valueType,
+		Slope: DEFAULT_GANGLIA_METRIC_SLOPE,
+		Tmax:  DEFAULT_GANGLIA_METRIC_TMAX,
+		Unit:  unit,
+		Value: valueStr,
+	}
 }

--- a/sinks/gangliaSink.go
+++ b/sinks/gangliaSink.go
@@ -24,6 +24,7 @@ type GangliaSinkConfig struct {
 	AddTagsAsDesc   bool   `json:"add_tags_as_desc,omitempty"`
 	ClusterName     string `json:"cluster_name,omitempty"`
 	AddTypeToName   bool   `json:"add_type_to_name,omitempty"`
+	AddUnits        bool   `json:"add_units,omitempty"`
 }
 
 type GangliaSink struct {
@@ -38,6 +39,7 @@ func (s *GangliaSink) Init(config json.RawMessage) error {
 	s.name = "GangliaSink"
 	s.config.AddTagsAsDesc = false
 	s.config.AddGangliaGroup = false
+	s.config.AddUnits = false
 	if len(config) > 0 {
 		err := json.Unmarshal(config, &s.config)
 		if err != nil {
@@ -70,91 +72,48 @@ func (s *GangliaSink) Init(config json.RawMessage) error {
 
 func (s *GangliaSink) Write(point lp.CCMetric) error {
 	var err error = nil
-	var tagsstr []string
+	//var tagsstr []string
 	var argstr []string
-	if s.config.AddGangliaGroup {
-		if point.HasTag("group") {
-			g, _ := point.GetTag("group")
-			argstr = append(argstr, fmt.Sprintf("--group=%s", g))
-		} else if point.HasMeta("group") {
-			g, _ := point.GetMeta("group")
-			argstr = append(argstr, fmt.Sprintf("--group=%s", g))
-		}
+
+	// Get metric name
+	metricname := GangliaMetricRename(point.Name())
+
+	// Get metric config (type, value, ... in suitable format)
+	conf := GetCommonGangliaConfig(point)
+	if len(conf.Type) == 0 {
+		conf = GetGangliaConfig(point)
+	}
+	if len(conf.Type) == 0 {
+		return fmt.Errorf("metric %s has no 'value' field", metricname)
 	}
 
-	for key, value := range point.Tags() {
-		switch key {
-		case "unit":
-			argstr = append(argstr, fmt.Sprintf("--units=%s", value))
-		default:
-			tagsstr = append(tagsstr, fmt.Sprintf("%s=%s", key, value))
-		}
+	if s.config.AddGangliaGroup {
+		argstr = append(argstr, fmt.Sprintf("--group=%s", conf.Group))
 	}
-	if s.config.MetaAsTags {
-		for key, value := range point.Meta() {
-			switch key {
-			case "unit":
-				argstr = append(argstr, fmt.Sprintf("--units=%s", value))
-			default:
-				tagsstr = append(tagsstr, fmt.Sprintf("%s=%s", key, value))
-			}
-		}
+	if s.config.AddUnits && len(conf.Unit) > 0 {
+		argstr = append(argstr, fmt.Sprintf("--units=%s", conf.Unit))
 	}
+
 	if len(s.config.ClusterName) > 0 {
 		argstr = append(argstr, fmt.Sprintf("--cluster=%s", s.config.ClusterName))
 	}
-	if s.config.AddTagsAsDesc && len(tagsstr) > 0 {
-		argstr = append(argstr, fmt.Sprintf("--desc=%q", strings.Join(tagsstr, ",")))
-	}
+	// if s.config.AddTagsAsDesc && len(tagsstr) > 0 {
+	// 	argstr = append(argstr, fmt.Sprintf("--desc=%q", strings.Join(tagsstr, ",")))
+	// }
 	if len(s.gmetric_config) > 0 {
 		argstr = append(argstr, fmt.Sprintf("--conf=%s", s.gmetric_config))
 	}
-	name := GangliaMetricRename(point)
 	if s.config.AddTypeToName {
 		argstr = append(argstr, fmt.Sprintf("--name=%s", GangliaMetricName(point)))
 	} else {
-		argstr = append(argstr, fmt.Sprintf("--name=%s", name))
+		argstr = append(argstr, fmt.Sprintf("--name=%s", metricname))
 	}
-	slope := GangliaSlopeType(point)
-	slopeStr := "both"
-	if slope == 0 {
-		slopeStr = "zero"
-	}
-	argstr = append(argstr, fmt.Sprintf("--slope=%s", slopeStr))
+	argstr = append(argstr, fmt.Sprintf("--slope=%s", conf.Slope))
+	argstr = append(argstr, fmt.Sprintf("--value=%s", conf.Value))
+	argstr = append(argstr, fmt.Sprintf("--type=%s", conf.Type))
+	argstr = append(argstr, fmt.Sprintf("--tmax=%d", conf.Tmax))
 
-	for k, v := range point.Fields() {
-		if k == "value" {
-			switch value := v.(type) {
-			case float64:
-				argstr = append(argstr,
-					fmt.Sprintf("--value=%v", value), "--type=double")
-			case float32:
-				argstr = append(argstr,
-					fmt.Sprintf("--value=%v", value), "--type=float")
-			case int:
-				argstr = append(argstr,
-					fmt.Sprintf("--value=%d", value), "--type=int32")
-			case int32:
-				argstr = append(argstr,
-					fmt.Sprintf("--value=%d", value), "--type=int32")
-			case int64:
-				argstr = append(argstr,
-					fmt.Sprintf("--value=%d", value), "--type=int32")
-			case uint:
-				argstr = append(argstr,
-					fmt.Sprintf("--value=%d", value), "--type=uint32")
-			case uint32:
-				argstr = append(argstr,
-					fmt.Sprintf("--value=%d", value), "--type=uint32")
-			case uint64:
-				argstr = append(argstr,
-					fmt.Sprintf("--value=%d", value), "--type=uint32")
-			case string:
-				argstr = append(argstr,
-					fmt.Sprintf("--value=%q", value), "--type=string")
-			}
-		}
-	}
+	cclog.ComponentDebug(s.name, s.gmetric_path, strings.Join(argstr, " "))
 	command := exec.Command(s.gmetric_path, argstr...)
 	command.Wait()
 	_, err = command.Output()


### PR DESCRIPTION
This PR adds the configuration found in the default Ganglia modules to send the important metrics for Ganglia in the exact format