### PR TITLE
Unit system for the ClusterCockpit ecosystem

### DIFF
--- a/internal/ccUnits/README.md
+++ b/internal/ccUnits/README.md
@@ -1,0 +1,93 @@
+# ccUnits - A unit system for ClusterCockpit
+
+When working with metrics, the problem comes up that they may use different unit name but have the same unit in fact. There are a lot of real world examples like 'kB' and 'Kbyte'. In CC Metric Collector, the Collectors read data from different sources which may use different units or the programmer specifies a unit for a metric by hand. In order to enable unit comparison and conversion, the ccUnits package provides some helpers:
+
+There are basically two important functions:
+```go
+NewUnit(unit string) Unit
+GetUnitPrefixFactor(in, out Unit) (float64, error) // Get the prefix difference for conversion
+```
+
+In order to get the "normalized" string unit back, you can use:
+```go
+u := NewUnit("MB")
+fmt.Printf("Long string %q", u.String())
+fmt.Printf("Short string %q", u.Short())
+```
+
+If you have two units and need the conversion factor:
+```go
+u1 := NewUnit("kB")
+u2 := NewUnit("MBytes")
+factor, err := GetUnitPrefixFactor(u1, u2) // Returns an error if the units have different measures
+if err == nil {
+    v2 := v1 * factor
+}
+```
+
+If you have a metric and want the derivation to a bandwidth or events per second, you can use the original unit:
+
+```go
+in_unit, err := metric.GetMeta("unit")
+if err == nil {
+    value, ok := metric.GetField("value")
+    if ok {
+        out_unit = NewUnit(in_unit)
+        out_unit.AddDivisorUnit("seconds")
+        y, err := lp.New(metric.Name()+"_bw",
+                         metric.Tags(),
+                         metric.Meta(),
+                         map[string]interface{"value": value/time},
+                         metric.Time())
+        if err == nil {
+            y.AddMeta("unit", out_unit.Short())
+        }
+    }
+}
+```
+
+## Supported prefixes
+
+```go
+const (
+	Base  Prefix = iota
+	Peta         = 1e15
+	Tera         = 1e12
+	Giga         = 1e9
+	Mega         = 1e6
+	Kilo         = 1e3
+	Milli        = 1e-3
+	Micro        = 1e-6
+	Nano         = 1e-9
+	Kibi         = 1024
+	Mebi         = 1024 * 1024
+	Gibi         = 1024 * 1024 * 1024
+	Tebi         = 1024 * 1024 * 1024 * 1024
+)
+```
+
+The prefixes are detected using a regular expression `^([kKmMgGtTpP]?[i]?)(.*)` that splits the prefix from the measure. You probably don't need to deal with the prefixes in the code.
+
+## Supported measures
+
+```go
+const (
+	None Measure = iota
+	Bytes
+	Flops
+	Percentage
+	TemperatureC
+	TemperatureF
+	Rotation
+	Hertz
+	Time
+	Power
+	Energy
+	Cycles
+	Requests
+	Packets
+	Events
+)
+```
+
+There a regular expression for each of the measures like `^([bB][yY]?[tT]?[eE]?[sS]?)` for the `Bytes` measure. 

--- a/internal/ccUnits/README.md
+++ b/internal/ccUnits/README.md
@@ -72,14 +72,16 @@ Special parsing rules for the following measures: iff `prefix==Milli`, use `pref
   - `Cycles`
   - `Requests`
 
-This means the prefixes `Micro` (like `ubytes`) and `Nano` like (`nflops/sec`) are not allowed and return an invalid unit.
+This means the prefixes `Micro` (like `ubytes`) and `Nano` like (`nflops/sec`) are not allowed and return an invalid unit. But you can specify `mflops` and `mb`.
 
+Prefixes for `%` or `percent` are ignored.
 
 ## Supported prefixes
 
 ```go
 const (
 	Base  Prefix = iota
+	Exa          = 1e18
 	Peta         = 1e15
 	Tera         = 1e12
 	Giga         = 1e9
@@ -110,8 +112,8 @@ const (
 	Rotation
 	Hertz
 	Time
-	Power
-	Energy
+	Watt
+	Joule
 	Cycles
 	Requests
 	Packets
@@ -141,4 +143,10 @@ If there are special conversation rules between measures and you want to convert
 The two parsers for prefix and measure are called under the hood by `NewUnit()` and there might some special rules apply. Like in the above section about 'special unit detection', special rules for your new measure might be required. Currently there are two special cases:
 
 - Measures that are non-dividable like Flops, Bytes, Events, ... cannot use `Milli`, `Micro` and `Nano`. The prefix `m` is forced to `M` for these measures
-- If the prefix is `p`/`P` (`Peta`) or `e`/`E` (`Exa`) and the measure is not detectable, it retries detection with the prefix. So first round it tries for example (prefix `p`, measure `ackets`) which fails, to it retries with (measure `packets` and no prefix).
+- If the prefix is `p`/`P` (`Peta`) or `e`/`E` (`Exa`) and the measure is not detectable, it retries detection with the prefix. So first round it tries, for example, prefix `p` and measure `ackets` which fails, so it retries the detection with measure `packets` and `<empty>` prefix (resolves to `Base` prefix).
+
+## Limitations
+
+The `ccUnits` package is a simple implemtation of a unit system and comes with some limitations:
+
+- The unit denominator (like `s` in `Mbyte/s`) can only have the `Base` prefix, you cannot specify `Byte/ms` for "Bytes per milli second".

--- a/internal/ccUnits/ccUnitMeasure.go
+++ b/internal/ccUnits/ccUnitMeasure.go
@@ -94,7 +94,7 @@ func (m *Measure) Short() string {
 
 const bytesRegexStr = `^([bB][yY]?[tT]?[eE]?[sS]?)`
 const flopsRegexStr = `^([fF][lL]?[oO]?[pP]?[sS]?)`
-const percentRegexStr = `^(%%|[pP]ercent)`
+const percentRegexStr = `^(%|[pP]ercent)`
 const degreeCRegexStr = `^(deg[Cc]|°[cC])`
 const degreeFRegexStr = `^(deg[fF]|°[fF])`
 const rpmRegexStr = `^([rR][pP][mM])`
@@ -105,6 +105,7 @@ const energyRegexStr = `^([jJ][oO]?[uU]?[lL]?[eE]?[sS]?)`
 const cyclesRegexStr = `^([cC][yY][cC]?[lL]?[eE]?[sS]?)`
 const requestsRegexStr = `^([rR][eE][qQ][uU]?[eE]?[sS]?[tT]?[sS]?)`
 const packetsRegexStr = `^([pP][aA]?[cC]?[kK][eE]?[tT][sS]?)`
+const eventsRegexStr = `^([eE][vV]?[eE]?[nN][tT][sS]?)`
 
 var bytesRegex = regexp.MustCompile(bytesRegexStr)
 var flopsRegex = regexp.MustCompile(flopsRegexStr)
@@ -119,6 +120,7 @@ var energyRegex = regexp.MustCompile(energyRegexStr)
 var cyclesRegex = regexp.MustCompile(cyclesRegexStr)
 var requestsRegex = regexp.MustCompile(requestsRegexStr)
 var packetsRegex = regexp.MustCompile(packetsRegexStr)
+var eventsRegex = regexp.MustCompile(eventsRegexStr)
 
 func NewMeasure(unit string) Measure {
 	var match []string
@@ -173,6 +175,10 @@ func NewMeasure(unit string) Measure {
 	match = packetsRegex.FindStringSubmatch(unit)
 	if match != nil {
 		return Packets
+	}
+	match = eventsRegex.FindStringSubmatch(unit)
+	if match != nil {
+		return Events
 	}
 	return None
 }

--- a/internal/ccUnits/ccUnitMeasure.go
+++ b/internal/ccUnits/ccUnitMeasure.go
@@ -14,8 +14,8 @@ const (
 	Rotation
 	Hertz
 	Time
-	Power
-	Energy
+	Watt
+	Joule
 	Cycles
 	Requests
 	Packets
@@ -40,9 +40,9 @@ func (m *Measure) String() string {
 		return "Hertz"
 	case Time:
 		return "Seconds"
-	case Power:
+	case Watt:
 		return "Watts"
-	case Energy:
+	case Joule:
 		return "Joules"
 	case Cycles:
 		return "Cycles"
@@ -75,9 +75,9 @@ func (m *Measure) Short() string {
 		return "Hz"
 	case Time:
 		return "s"
-	case Power:
+	case Watt:
 		return "W"
-	case Energy:
+	case Joule:
 		return "J"
 	case Cycles:
 		return "cyc"
@@ -100,8 +100,8 @@ const degreeFRegexStr = `^(deg[fF]|°[fF])`
 const rpmRegexStr = `^([rR][pP][mM])`
 const hertzRegexStr = `^([hH][eE]?[rR]?[tT]?[zZ])`
 const timeRegexStr = `^([sS][eE]?[cC]?[oO]?[nN]?[dD]?[sS]?)`
-const powerRegexStr = `^([wW][aA]?[tT]?[tT]?[sS]?)`
-const energyRegexStr = `^([jJ][oO]?[uU]?[lL]?[eE]?[sS]?)`
+const wattRegexStr = `^([wW][aA]?[tT]?[tT]?[sS]?)`
+const jouleRegexStr = `^([jJ][oO]?[uU]?[lL]?[eE]?[sS]?)`
 const cyclesRegexStr = `^([cC][yY][cC]?[lL]?[eE]?[sS]?)`
 const requestsRegexStr = `^([rR][eE][qQ][uU]?[eE]?[sS]?[tT]?[sS]?)`
 const packetsRegexStr = `^([pP][aA]?[cC]?[kK][eE]?[tT][sS]?)`
@@ -115,8 +115,8 @@ var degreeFRegex = regexp.MustCompile(degreeFRegexStr)
 var rpmRegex = regexp.MustCompile(rpmRegexStr)
 var hertzRegex = regexp.MustCompile(hertzRegexStr)
 var timeRegex = regexp.MustCompile(timeRegexStr)
-var powerRegex = regexp.MustCompile(powerRegexStr)
-var energyRegex = regexp.MustCompile(energyRegexStr)
+var wattRegex = regexp.MustCompile(wattRegexStr)
+var jouleRegex = regexp.MustCompile(jouleRegexStr)
 var cyclesRegex = regexp.MustCompile(cyclesRegexStr)
 var requestsRegex = regexp.MustCompile(requestsRegexStr)
 var packetsRegex = regexp.MustCompile(packetsRegexStr)
@@ -160,13 +160,13 @@ func NewMeasure(unit string) Measure {
 	if match != nil {
 		return Cycles
 	}
-	match = powerRegex.FindStringSubmatch(unit)
+	match = wattRegex.FindStringSubmatch(unit)
 	if match != nil {
-		return Power
+		return Watt
 	}
-	match = energyRegex.FindStringSubmatch(unit)
+	match = jouleRegex.FindStringSubmatch(unit)
 	if match != nil {
-		return Energy
+		return Joule
 	}
 	match = requestsRegex.FindStringSubmatch(unit)
 	if match != nil {

--- a/internal/ccUnits/ccUnitMeasure.go
+++ b/internal/ccUnits/ccUnitMeasure.go
@@ -1,0 +1,178 @@
+package ccunits
+
+import "regexp"
+
+type Measure int
+
+const (
+	None Measure = iota
+	Bytes
+	Flops
+	Percentage
+	TemperatureC
+	TemperatureF
+	Rotation
+	Hertz
+	Time
+	Power
+	Energy
+	Cycles
+	Requests
+	Packets
+	Events
+)
+
+func (m *Measure) String() string {
+	switch *m {
+	case Bytes:
+		return "Bytes"
+	case Flops:
+		return "Flops"
+	case Percentage:
+		return "Percent"
+	case TemperatureC:
+		return "DegreeC"
+	case TemperatureF:
+		return "DegreeF"
+	case Rotation:
+		return "RPM"
+	case Hertz:
+		return "Hertz"
+	case Time:
+		return "Seconds"
+	case Power:
+		return "Watts"
+	case Energy:
+		return "Joules"
+	case Cycles:
+		return "Cycles"
+	case Requests:
+		return "Requests"
+	case Packets:
+		return "Packets"
+	case Events:
+		return "Events"
+	default:
+		return "Unknown"
+	}
+}
+
+func (m *Measure) Short() string {
+	switch *m {
+	case Bytes:
+		return "Bytes"
+	case Flops:
+		return "Flops"
+	case Percentage:
+		return "Percent"
+	case TemperatureC:
+		return "degC"
+	case TemperatureF:
+		return "degF"
+	case Rotation:
+		return "RPM"
+	case Hertz:
+		return "Hz"
+	case Time:
+		return "s"
+	case Power:
+		return "W"
+	case Energy:
+		return "J"
+	case Cycles:
+		return "cyc"
+	case Requests:
+		return "requests"
+	case Packets:
+		return "packets"
+	case Events:
+		return "events"
+	default:
+		return "Unknown"
+	}
+}
+
+const bytesRegexStr = `^([bB][yY]?[tT]?[eE]?[sS]?)`
+const flopsRegexStr = `^([fF][lL]?[oO]?[pP]?[sS]?)`
+const percentRegexStr = `^(%%|[pP]ercent)`
+const degreeCRegexStr = `^(deg[Cc]|°[cC])`
+const degreeFRegexStr = `^(deg[fF]|°[fF])`
+const rpmRegexStr = `^([rR][pP][mM])`
+const hertzRegexStr = `^([hH][eE]?[rR]?[tT]?[zZ])`
+const timeRegexStr = `^([sS][eE]?[cC]?[oO]?[nN]?[dD]?[sS]?)`
+const powerRegexStr = `^([wW][aA]?[tT]?[tT]?[sS]?)`
+const energyRegexStr = `^([jJ][oO]?[uU]?[lL]?[eE]?[sS]?)`
+const cyclesRegexStr = `^([cC][yY][cC]?[lL]?[eE]?[sS]?)`
+const requestsRegexStr = `^([rR][eE][qQ][uU]?[eE]?[sS]?[tT]?[sS]?)`
+const packetsRegexStr = `^([pP][aA]?[cC]?[kK][eE]?[tT][sS]?)`
+
+var bytesRegex = regexp.MustCompile(bytesRegexStr)
+var flopsRegex = regexp.MustCompile(flopsRegexStr)
+var percentRegex = regexp.MustCompile(percentRegexStr)
+var degreeCRegex = regexp.MustCompile(degreeCRegexStr)
+var degreeFRegex = regexp.MustCompile(degreeFRegexStr)
+var rpmRegex = regexp.MustCompile(rpmRegexStr)
+var hertzRegex = regexp.MustCompile(hertzRegexStr)
+var timeRegex = regexp.MustCompile(timeRegexStr)
+var powerRegex = regexp.MustCompile(powerRegexStr)
+var energyRegex = regexp.MustCompile(energyRegexStr)
+var cyclesRegex = regexp.MustCompile(cyclesRegexStr)
+var requestsRegex = regexp.MustCompile(requestsRegexStr)
+var packetsRegex = regexp.MustCompile(packetsRegexStr)
+
+func NewMeasure(unit string) Measure {
+	var match []string
+	match = bytesRegex.FindStringSubmatch(unit)
+	if match != nil {
+		return Bytes
+	}
+	match = flopsRegex.FindStringSubmatch(unit)
+	if match != nil {
+		return Flops
+	}
+	match = percentRegex.FindStringSubmatch(unit)
+	if match != nil {
+		return Percentage
+	}
+	match = degreeCRegex.FindStringSubmatch(unit)
+	if match != nil {
+		return TemperatureC
+	}
+	match = degreeFRegex.FindStringSubmatch(unit)
+	if match != nil {
+		return TemperatureF
+	}
+	match = rpmRegex.FindStringSubmatch(unit)
+	if match != nil {
+		return Rotation
+	}
+	match = hertzRegex.FindStringSubmatch(unit)
+	if match != nil {
+		return Hertz
+	}
+	match = timeRegex.FindStringSubmatch(unit)
+	if match != nil {
+		return Time
+	}
+	match = cyclesRegex.FindStringSubmatch(unit)
+	if match != nil {
+		return Cycles
+	}
+	match = powerRegex.FindStringSubmatch(unit)
+	if match != nil {
+		return Power
+	}
+	match = energyRegex.FindStringSubmatch(unit)
+	if match != nil {
+		return Energy
+	}
+	match = requestsRegex.FindStringSubmatch(unit)
+	if match != nil {
+		return Requests
+	}
+	match = packetsRegex.FindStringSubmatch(unit)
+	if match != nil {
+		return Packets
+	}
+	return None
+}

--- a/internal/ccUnits/ccUnitPrefix.go
+++ b/internal/ccUnits/ccUnitPrefix.go
@@ -2,28 +2,28 @@ package ccunits
 
 import "regexp"
 
-type Scale float64
+type Prefix float64
 
 const (
-	Base  Scale = iota
-	Peta        = 1e15
-	Tera        = 1e12
-	Giga        = 1e9
-	Mega        = 1e6
-	Kilo        = 1e3
-	Milli       = 1e-3
-	Micro       = 1e-6
-	Nano        = 1e-9
-	Kibi        = 1024
-	Mebi        = 1024 * 1024
-	Gibi        = 1024 * 1024 * 1024
-	Tebi        = 1024 * 1024 * 1024 * 1024
+	Base  Prefix = iota
+	Peta         = 1e15
+	Tera         = 1e12
+	Giga         = 1e9
+	Mega         = 1e6
+	Kilo         = 1e3
+	Milli        = 1e-3
+	Micro        = 1e-6
+	Nano         = 1e-9
+	Kibi         = 1024
+	Mebi         = 1024 * 1024
+	Gibi         = 1024 * 1024 * 1024
+	Tebi         = 1024 * 1024 * 1024 * 1024
 )
 const prefixRegexStr = `^([kKmMgGtTpP]?[i]?)(.*)`
 
 var prefixRegex = regexp.MustCompile(prefixRegexStr)
 
-func (s *Scale) String() string {
+func (s *Prefix) String() string {
 	switch *s {
 	case Base:
 		return ""
@@ -56,7 +56,7 @@ func (s *Scale) String() string {
 	}
 }
 
-func (s *Scale) Prefix() string {
+func (s *Prefix) Prefix() string {
 	switch *s {
 	case Base:
 		return ""
@@ -89,7 +89,7 @@ func (s *Scale) Prefix() string {
 	}
 }
 
-func NewScale(prefix string) Scale {
+func NewPrefix(prefix string) Prefix {
 	switch prefix {
 	case "k":
 		return Kilo

--- a/internal/ccUnits/ccUnitPrefix.go
+++ b/internal/ccUnits/ccUnitPrefix.go
@@ -5,7 +5,7 @@ import "regexp"
 type Prefix float64
 
 const (
-	Base  Prefix = iota
+	Base  Prefix = 1
 	Exa          = 1e18
 	Peta         = 1e15
 	Tera         = 1e12

--- a/internal/ccUnits/ccUnitPrefix.go
+++ b/internal/ccUnits/ccUnitPrefix.go
@@ -6,6 +6,7 @@ type Prefix float64
 
 const (
 	Base  Prefix = iota
+	Exa          = 1e18
 	Peta         = 1e15
 	Tera         = 1e12
 	Giga         = 1e9
@@ -37,6 +38,8 @@ func (s *Prefix) String() string {
 		return "Tera"
 	case Peta:
 		return "Peta"
+	case Exa:
+		return "Exa"
 	case Milli:
 		return "Milli"
 	case Micro:
@@ -70,6 +73,8 @@ func (s *Prefix) Prefix() string {
 		return "T"
 	case Peta:
 		return "P"
+	case Exa:
+		return "E"
 	case Milli:
 		return "m"
 	case Micro:
@@ -107,6 +112,14 @@ func NewPrefix(prefix string) Prefix {
 		return Tera
 	case "T":
 		return Tera
+	case "p":
+		return Peta
+	case "P":
+		return Peta
+	case "e":
+		return Exa
+	case "E":
+		return Exa
 	case "u":
 		return Micro
 	case "n":

--- a/internal/ccUnits/ccUnitScale.go
+++ b/internal/ccUnits/ccUnitScale.go
@@ -1,0 +1,131 @@
+package ccunits
+
+import "regexp"
+
+type Scale float64
+
+const (
+	Base  Scale = iota
+	Peta        = 1e15
+	Tera        = 1e12
+	Giga        = 1e9
+	Mega        = 1e6
+	Kilo        = 1e3
+	Milli       = 1e-3
+	Micro       = 1e-6
+	Nano        = 1e-9
+	Kibi        = 1024
+	Mebi        = 1024 * 1024
+	Gibi        = 1024 * 1024 * 1024
+	Tebi        = 1024 * 1024 * 1024 * 1024
+)
+const prefixRegexStr = `^([kKmMgGtTpP]?[i]?)(.*)`
+
+var prefixRegex = regexp.MustCompile(prefixRegexStr)
+
+func (s *Scale) String() string {
+	switch *s {
+	case Base:
+		return ""
+	case Kilo:
+		return "Kilo"
+	case Mega:
+		return "Mega"
+	case Giga:
+		return "Giga"
+	case Tera:
+		return "Tera"
+	case Peta:
+		return "Peta"
+	case Milli:
+		return "Milli"
+	case Micro:
+		return "Micro"
+	case Nano:
+		return "Nano"
+	case Kibi:
+		return "Kibi"
+	case Mebi:
+		return "Mebi"
+	case Gibi:
+		return "Gibi"
+	case Tebi:
+		return "Tebi"
+	default:
+		return "Unkn"
+	}
+}
+
+func (s *Scale) Prefix() string {
+	switch *s {
+	case Base:
+		return ""
+	case Kilo:
+		return "K"
+	case Mega:
+		return "M"
+	case Giga:
+		return "G"
+	case Tera:
+		return "T"
+	case Peta:
+		return "P"
+	case Milli:
+		return "m"
+	case Micro:
+		return "u"
+	case Nano:
+		return "n"
+	case Kibi:
+		return "Ki"
+	case Mebi:
+		return "Mi"
+	case Gibi:
+		return "Gi"
+	case Tebi:
+		return "Ti"
+	default:
+		return "<unkn>"
+	}
+}
+
+func NewScale(prefix string) Scale {
+	switch prefix {
+	case "k":
+		return Kilo
+	case "K":
+		return Kilo
+	case "m":
+		return Milli
+	case "M":
+		return Mega
+	case "g":
+		return Giga
+	case "G":
+		return Giga
+	case "t":
+		return Tera
+	case "T":
+		return Tera
+	case "u":
+		return Micro
+	case "n":
+		return Nano
+	case "ki":
+		return Kibi
+	case "Ki":
+		return Kibi
+	case "Mi":
+		return Mebi
+	case "gi":
+		return Gibi
+	case "Gi":
+		return Gibi
+	case "Ti":
+		return Tebi
+	case "":
+		return Base
+	default:
+		return Base
+	}
+}

--- a/internal/ccUnits/ccUnits.go
+++ b/internal/ccUnits/ccUnits.go
@@ -59,14 +59,8 @@ func (u *unit) getDivMeasure() Measure {
 
 func GetPrefixFactor(in Prefix, out Prefix) func(value float64) float64 {
 	var factor = 1.0
-	var in_prefix = 1.0
-	var out_prefix = 1.0
-	if in != Base {
-		in_prefix = float64(in)
-	}
-	if out != Base {
-		out_prefix = float64(out)
-	}
+	var in_prefix = float64(in)
+	var out_prefix = float64(out)
 	factor = in_prefix / out_prefix
 	return func(value float64) float64 { return factor }
 }
@@ -110,12 +104,16 @@ func NewUnit(unitStr string) Unit {
 		if len(measures) > 1 {
 			div = NewMeasure(measures[1])
 		}
-		// Special case for 'm' as prefix for Bytes as thers is nothing like MilliBytes
+
 		switch m {
+		// Special case for 'm' as prefix for Bytes and some others as thers is no unit like MilliBytes
 		case Bytes, Flops, Packets, Events, Cycles, Requests:
 			if pre == Milli {
 				pre = Mega
 			}
+		// Special case for percentage. No/ignore prefix
+		case Percentage:
+			pre = Base
 		}
 		u.prefix = pre
 		u.measure = m

--- a/internal/ccUnits/ccUnits.go
+++ b/internal/ccUnits/ccUnits.go
@@ -96,8 +96,9 @@ func NewUnit(unitStr string) Unit {
 		// Special case for prefix 'p' or 'P' (Peta) and measures starting with 'p' or 'P'
 		// like 'packets' or 'percent'. Same for 'e' or 'E' (Exa) for measures starting with
 		// 'e' or 'E' like 'events'
-		if m == None && pre == Base {
-			if strings.ToLower(matches[1]) == "p" || strings.ToLower(matches[1]) == "e" {
+		if m == None {
+			switch pre {
+			case Peta, Exa:
 				t := NewMeasure(matches[1] + measures[0])
 				if t != None {
 					m = t
@@ -111,27 +112,7 @@ func NewUnit(unitStr string) Unit {
 		}
 		// Special case for 'm' as prefix for Bytes as thers is nothing like MilliBytes
 		switch m {
-		case Bytes:
-			if pre == Milli {
-				pre = Mega
-			}
-		case Flops:
-			if pre == Milli {
-				pre = Mega
-			}
-		case Packets:
-			if pre == Milli {
-				pre = Mega
-			}
-		case Events:
-			if pre == Milli {
-				pre = Mega
-			}
-		case Cycles:
-			if pre == Milli {
-				pre = Mega
-			}
-		case Requests:
+		case Bytes, Flops, Packets, Events, Cycles, Requests:
 			if pre == Milli {
 				pre = Mega
 			}

--- a/internal/ccUnits/ccUnits.go
+++ b/internal/ccUnits/ccUnits.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Unit struct {
-	scale      Scale
+	scale      Prefix
 	measure    Measure
 	divMeasure Measure
 }
@@ -31,7 +31,7 @@ func (u *Unit) AddDivisorUnit(div Measure) {
 	u.divMeasure = div
 }
 
-func GetScaleFactor(in Scale, out Scale) float64 {
+func GetPrefixFactor(in Prefix, out Prefix) float64 {
 	var factor = 1.0
 	var in_scale = 1.0
 	var out_scale = 1.0
@@ -45,11 +45,11 @@ func GetScaleFactor(in Scale, out Scale) float64 {
 	return factor
 }
 
-func GetUnitScaleFactor(in Unit, out Unit) (float64, error) {
+func GetUnitPrefixFactor(in Unit, out Unit) (float64, error) {
 	if in.measure != out.measure || in.divMeasure != out.divMeasure {
 		return 1.0, fmt.Errorf("invalid measures in in and out Unit")
 	}
-	return GetScaleFactor(in.scale, out.scale), nil
+	return GetPrefixFactor(in.scale, out.scale), nil
 }
 
 func NewUnit(unit string) Unit {
@@ -60,7 +60,7 @@ func NewUnit(unit string) Unit {
 	}
 	matches := prefixRegex.FindStringSubmatch(unit)
 	if len(matches) > 2 {
-		u.scale = NewScale(matches[1])
+		u.scale = NewPrefix(matches[1])
 		measures := strings.Split(matches[2], "/")
 		u.measure = NewMeasure(measures[0])
 		// Special case for 'm' as scale for Bytes as thers is nothing like MilliBytes

--- a/internal/ccUnits/ccUnits.go
+++ b/internal/ccUnits/ccUnits.go
@@ -1,0 +1,75 @@
+package ccunits
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Unit struct {
+	scale      Scale
+	measure    Measure
+	divMeasure Measure
+}
+
+func (u *Unit) String() string {
+	if u.divMeasure != None {
+		return fmt.Sprintf("%s%s/%s", u.scale.String(), u.measure.String(), u.divMeasure.String())
+	} else {
+		return fmt.Sprintf("%s%s", u.scale.String(), u.measure.String())
+	}
+}
+
+func (u *Unit) Short() string {
+	if u.divMeasure != None {
+		return fmt.Sprintf("%s%s/%s", u.scale.Prefix(), u.measure.Short(), u.divMeasure.Short())
+	} else {
+		return fmt.Sprintf("%s%s", u.scale.Prefix(), u.measure.Short())
+	}
+}
+
+func (u *Unit) AddDivisorUnit(div Measure) {
+	u.divMeasure = div
+}
+
+func GetScaleFactor(in Scale, out Scale) float64 {
+	var factor = 1.0
+	var in_scale = 1.0
+	var out_scale = 1.0
+	if in != Base {
+		in_scale = float64(in)
+	}
+	if out != Base {
+		out_scale = float64(out)
+	}
+	factor = in_scale / out_scale
+	return factor
+}
+
+func GetUnitScaleFactor(in Unit, out Unit) (float64, error) {
+	if in.measure != out.measure || in.divMeasure != out.divMeasure {
+		return 1.0, fmt.Errorf("invalid measures in in and out Unit")
+	}
+	return GetScaleFactor(in.scale, out.scale), nil
+}
+
+func NewUnit(unit string) Unit {
+	u := Unit{
+		scale:      Base,
+		measure:    None,
+		divMeasure: None,
+	}
+	matches := prefixRegex.FindStringSubmatch(unit)
+	if len(matches) > 2 {
+		u.scale = NewScale(matches[1])
+		measures := strings.Split(matches[2], "/")
+		u.measure = NewMeasure(measures[0])
+		// Special case for 'm' as scale for Bytes as thers is nothing like MilliBytes
+		if u.measure == Bytes && u.scale == Milli {
+			u.scale = Mega
+		}
+		if len(measures) > 1 {
+			u.divMeasure = NewMeasure(measures[1])
+		}
+	}
+	return u
+}

--- a/internal/ccUnits/ccUnits_test.go
+++ b/internal/ccUnits/ccUnits_test.go
@@ -60,6 +60,10 @@ func TestUnitsExact(t *testing.T) {
 		{"secs", NewUnit("seconds")},
 		{"RPM", NewUnit("rpm")},
 		{"rPm", NewUnit("rpm")},
+		{"watt/byte", NewUnit("W/B")},
+		{"watts/bytes", NewUnit("W/B")},
+		{"flop/byte", NewUnit("flops/Bytes")},
+		{"F/B", NewUnit("flops/Bytes")},
 	}
 	compareUnitExact := func(in, out Unit) bool {
 		if in.getMeasure() == out.getMeasure() && in.getDivMeasure() == out.getDivMeasure() && in.getPrefix() == out.getPrefix() {

--- a/internal/ccUnits/ccUnits_test.go
+++ b/internal/ccUnits/ccUnits_test.go
@@ -40,16 +40,36 @@ func TestUnitsExact(t *testing.T) {
 		{"degC", NewUnit("degC")},
 		{"degf", NewUnit("degF")},
 		{"°f", NewUnit("degF")},
+		{"events", NewUnit("events")},
+		{"event", NewUnit("events")},
+		{"EveNts", NewUnit("events")},
+		{"reqs", NewUnit("requests")},
+		{"requests", NewUnit("requests")},
+		{"Requests", NewUnit("requests")},
+		{"cyc", NewUnit("cycles")},
+		{"cy", NewUnit("cycles")},
+		{"Cycles", NewUnit("cycles")},
+		{"J", NewUnit("Joules")},
+		{"Joule", NewUnit("Joules")},
+		{"joule", NewUnit("Joules")},
+		{"W", NewUnit("Watt")},
+		{"Watts", NewUnit("Watt")},
+		{"watt", NewUnit("Watt")},
+		{"s", NewUnit("seconds")},
+		{"sec", NewUnit("seconds")},
+		{"secs", NewUnit("seconds")},
+		{"RPM", NewUnit("rpm")},
+		{"rPm", NewUnit("rpm")},
 	}
 	compareUnitExact := func(in, out Unit) bool {
-		if in.measure == out.measure && in.divMeasure == out.divMeasure && in.scale == out.scale {
+		if in.getMeasure() == out.getMeasure() && in.getDivMeasure() == out.getDivMeasure() && in.getPrefix() == out.getPrefix() {
 			return true
 		}
 		return false
 	}
 	for _, c := range testCases {
 		u := NewUnit(c.in)
-		if !compareUnitExact(u, c.want) {
+		if (!u.Valid()) || (!compareUnitExact(u, c.want)) {
 			t.Errorf("func NewUnit(%q) == %q, want %q", c.in, u.String(), c.want.String())
 		}
 	}
@@ -57,9 +77,9 @@ func TestUnitsExact(t *testing.T) {
 
 func TestUnitsDifferentPrefix(t *testing.T) {
 	testCases := []struct {
-		in          string
-		want        Unit
-		scaleFactor float64
+		in           string
+		want         Unit
+		prefixFactor float64
 	}{
 		{"kb", NewUnit("Bytes"), 1000},
 		{"Mb", NewUnit("Bytes"), 1000000},
@@ -72,19 +92,19 @@ func TestUnitsDifferentPrefix(t *testing.T) {
 		{"mb", NewUnit("MBytes"), 1.0},
 	}
 	compareUnitWithPrefix := func(in, out Unit, factor float64) bool {
-		if in.measure == out.measure && in.divMeasure == out.divMeasure {
-			if f := GetPrefixFactor(in.scale, out.scale); f == factor {
+		if in.getMeasure() == out.getMeasure() && in.getDivMeasure() == out.getDivMeasure() {
+			if f := GetPrefixFactor(in.getPrefix(), out.getPrefix()); f(1.0) == factor {
 				return true
 			} else {
-				fmt.Println(f)
+				fmt.Println(f(1.0))
 			}
 		}
 		return false
 	}
 	for _, c := range testCases {
 		u := NewUnit(c.in)
-		if !compareUnitWithPrefix(u, c.want, c.scaleFactor) {
-			t.Errorf("func NewUnit(%q) == %q, want %q with factor %f", c.in, u.String(), c.want.String(), c.scaleFactor)
+		if (!u.Valid()) || (!compareUnitWithPrefix(u, c.want, c.prefixFactor)) {
+			t.Errorf("func NewUnit(%q) == %q, want %q with factor %f", c.in, u.String(), c.want.String(), c.prefixFactor)
 		}
 	}
 }

--- a/internal/ccUnits/ccUnits_test.go
+++ b/internal/ccUnits/ccUnits_test.go
@@ -1,0 +1,90 @@
+package ccunits
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestUnitsExact(t *testing.T) {
+	testCases := []struct {
+		in   string
+		want Unit
+	}{
+		{"b", NewUnit("Bytes")},
+		{"B", NewUnit("Bytes")},
+		{"byte", NewUnit("Bytes")},
+		{"bytes", NewUnit("Bytes")},
+		{"BYtes", NewUnit("Bytes")},
+		{"Mb", NewUnit("MBytes")},
+		{"MB", NewUnit("MBytes")},
+		{"Mbyte", NewUnit("MBytes")},
+		{"Mbytes", NewUnit("MBytes")},
+		{"MbYtes", NewUnit("MBytes")},
+		{"Gb", NewUnit("GBytes")},
+		{"GB", NewUnit("GBytes")},
+		{"Hz", NewUnit("Hertz")},
+		{"MHz", NewUnit("MHertz")},
+		{"GHertz", NewUnit("GHertz")},
+		{"pkts", NewUnit("Packets")},
+		{"packets", NewUnit("Packets")},
+		{"packet", NewUnit("Packets")},
+		{"flop", NewUnit("Flops")},
+		{"flops", NewUnit("Flops")},
+		{"floPS", NewUnit("Flops")},
+		{"Mflop", NewUnit("MFlops")},
+		{"Gflop", NewUnit("GFlops")},
+		{"gflop", NewUnit("GFlops")},
+		{"%", NewUnit("Percent")},
+		{"percent", NewUnit("Percent")},
+		{"degc", NewUnit("degC")},
+		{"degC", NewUnit("degC")},
+		{"degf", NewUnit("degF")},
+		{"°f", NewUnit("degF")},
+	}
+	compareUnitExact := func(in, out Unit) bool {
+		if in.measure == out.measure && in.divMeasure == out.divMeasure && in.scale == out.scale {
+			return true
+		}
+		return false
+	}
+	for _, c := range testCases {
+		u := NewUnit(c.in)
+		if !compareUnitExact(u, c.want) {
+			t.Errorf("func NewUnit(%q) == %q, want %q", c.in, u.String(), c.want.String())
+		}
+	}
+}
+
+func TestUnitsDifferentScale(t *testing.T) {
+	testCases := []struct {
+		in          string
+		want        Unit
+		scaleFactor float64
+	}{
+		{"kb", NewUnit("Bytes"), 1000},
+		{"Mb", NewUnit("Bytes"), 1000000},
+		{"Mb/s", NewUnit("Bytes/s"), 1000000},
+		{"Flops/s", NewUnit("MFlops/s"), 1e-6},
+		{"Flops/s", NewUnit("GFlops/s"), 1e-9},
+		{"MHz", NewUnit("Hertz"), 1e6},
+		{"kb", NewUnit("Kib"), 1000.0 / 1024},
+		{"Mib", NewUnit("MBytes"), (1024 * 1024.0) / (1e6)},
+		{"mb", NewUnit("MBytes"), 1.0},
+	}
+	compareUnitWithScale := func(in, out Unit, factor float64) bool {
+		if in.measure == out.measure && in.divMeasure == out.divMeasure {
+			if f := GetScaleFactor(in.scale, out.scale); f == factor {
+				return true
+			} else {
+				fmt.Println(f)
+			}
+		}
+		return false
+	}
+	for _, c := range testCases {
+		u := NewUnit(c.in)
+		if !compareUnitWithScale(u, c.want, c.scaleFactor) {
+			t.Errorf("func NewUnit(%q) == %q, want %q with factor %f", c.in, u.String(), c.want.String(), c.scaleFactor)
+		}
+	}
+}

--- a/internal/ccUnits/ccUnits_test.go
+++ b/internal/ccUnits/ccUnits_test.go
@@ -55,7 +55,7 @@ func TestUnitsExact(t *testing.T) {
 	}
 }
 
-func TestUnitsDifferentScale(t *testing.T) {
+func TestUnitsDifferentPrefix(t *testing.T) {
 	testCases := []struct {
 		in          string
 		want        Unit
@@ -71,9 +71,9 @@ func TestUnitsDifferentScale(t *testing.T) {
 		{"Mib", NewUnit("MBytes"), (1024 * 1024.0) / (1e6)},
 		{"mb", NewUnit("MBytes"), 1.0},
 	}
-	compareUnitWithScale := func(in, out Unit, factor float64) bool {
+	compareUnitWithPrefix := func(in, out Unit, factor float64) bool {
 		if in.measure == out.measure && in.divMeasure == out.divMeasure {
-			if f := GetScaleFactor(in.scale, out.scale); f == factor {
+			if f := GetPrefixFactor(in.scale, out.scale); f == factor {
 				return true
 			} else {
 				fmt.Println(f)
@@ -83,7 +83,7 @@ func TestUnitsDifferentScale(t *testing.T) {
 	}
 	for _, c := range testCases {
 		u := NewUnit(c.in)
-		if !compareUnitWithScale(u, c.want, c.scaleFactor) {
+		if !compareUnitWithPrefix(u, c.want, c.scaleFactor) {
 			t.Errorf("func NewUnit(%q) == %q, want %q with factor %f", c.in, u.String(), c.want.String(), c.scaleFactor)
 		}
 	}


### PR DESCRIPTION
This allows to use similar metric units in the whole ecosystem. Not all units are provided through the SI unit system like Bytes and Flops.

It tries to detect the prefix and measure with regular expressions, so it supports things like:
- `MBytes`
- `kB`
- `kBYtE`
- `°C`

The main idea is to make conversion between units easier by providing the conversion factors:
- `kByte` -> `Mbyte`
- `MByte/sec` - `GBytes/s`