### PR TITLE
Use old metric name in Ganglia if rename has happened in the router

### DIFF
--- a/sinks/gangliaCommon.go
+++ b/sinks/gangliaCommon.go
@@ -35,6 +35,8 @@ func GangliaMetricRename(name string) string {
 		return "pkts_out"
 	} else if name == "cpu_iowait" {
 		return "cpu_wio"
+	} else if name == "cpu_load" {
+		return "load_one"
 	}
 	return name
 }
@@ -148,10 +150,14 @@ type GangliaMetricConfig struct {
 	Unit  string
 	Group string
 	Value string
+	Name  string
 }
 
 func GetCommonGangliaConfig(point lp.CCMetric) GangliaMetricConfig {
 	mname := GangliaMetricRename(point.Name())
+	if oldname, ok := point.GetMeta("oldname"); ok {
+		mname = oldname
+	}
 	for _, group := range CommonGangliaMetrics {
 		for _, metric := range group.Metrics {
 			if metric.Name == mname {
@@ -187,6 +193,7 @@ func GetCommonGangliaConfig(point lp.CCMetric) GangliaMetricConfig {
 					Tmax:  metric.Tmax,
 					Unit:  metric.Unit,
 					Value: valueStr,
+					Name:  GangliaMetricRename(mname),
 				}
 			}
 		}
@@ -198,10 +205,15 @@ func GetCommonGangliaConfig(point lp.CCMetric) GangliaMetricConfig {
 		Tmax:  0,
 		Unit:  "",
 		Value: "",
+		Name:  "",
 	}
 }
 
 func GetGangliaConfig(point lp.CCMetric) GangliaMetricConfig {
+	mname := GangliaMetricRename(point.Name())
+	if oldname, ok := point.GetMeta("oldname"); ok {
+		mname = oldname
+	}
 	group := ""
 	if g, ok := point.GetMeta("group"); ok {
 		group = g
@@ -254,5 +266,6 @@ func GetGangliaConfig(point lp.CCMetric) GangliaMetricConfig {
 		Tmax:  DEFAULT_GANGLIA_METRIC_TMAX,
 		Unit:  unit,
 		Value: valueStr,
+		Name:  GangliaMetricRename(mname),
 	}
 }

--- a/sinks/gangliaCommon.go
+++ b/sinks/gangliaCommon.go
@@ -35,8 +35,6 @@ func GangliaMetricRename(name string) string {
 		return "pkts_out"
 	} else if name == "cpu_iowait" {
 		return "cpu_wio"
-	} else if name == "cpu_load" {
-		return "load_one"
 	}
 	return name
 }
@@ -156,7 +154,7 @@ type GangliaMetricConfig struct {
 func GetCommonGangliaConfig(point lp.CCMetric) GangliaMetricConfig {
 	mname := GangliaMetricRename(point.Name())
 	if oldname, ok := point.GetMeta("oldname"); ok {
-		mname = oldname
+		mname = GangliaMetricRename(oldname)
 	}
 	for _, group := range CommonGangliaMetrics {
 		for _, metric := range group.Metrics {
@@ -212,7 +210,7 @@ func GetCommonGangliaConfig(point lp.CCMetric) GangliaMetricConfig {
 func GetGangliaConfig(point lp.CCMetric) GangliaMetricConfig {
 	mname := GangliaMetricRename(point.Name())
 	if oldname, ok := point.GetMeta("oldname"); ok {
-		mname = oldname
+		mname = GangliaMetricRename(oldname)
 	}
 	group := ""
 	if g, ok := point.GetMeta("group"); ok {

--- a/sinks/gangliaSink.go
+++ b/sinks/gangliaSink.go
@@ -39,16 +39,13 @@ func (s *GangliaSink) Write(point lp.CCMetric) error {
 	//var tagsstr []string
 	var argstr []string
 
-	// Get metric name
-	metricname := GangliaMetricRename(point.Name())
-
 	// Get metric config (type, value, ... in suitable format)
 	conf := GetCommonGangliaConfig(point)
 	if len(conf.Type) == 0 {
 		conf = GetGangliaConfig(point)
 	}
 	if len(conf.Type) == 0 {
-		return fmt.Errorf("metric %s has no 'value' field", metricname)
+		return fmt.Errorf("metric %q (Ganglia name %q) has no 'value' field", point.Name(), conf.Name)
 	}
 
 	if s.config.AddGangliaGroup {
@@ -70,7 +67,7 @@ func (s *GangliaSink) Write(point lp.CCMetric) error {
 	if s.config.AddTypeToName {
 		argstr = append(argstr, fmt.Sprintf("--name=%s", GangliaMetricName(point)))
 	} else {
-		argstr = append(argstr, fmt.Sprintf("--name=%s", metricname))
+		argstr = append(argstr, fmt.Sprintf("--name=%s", conf.Name))
 	}
 	argstr = append(argstr, fmt.Sprintf("--slope=%s", conf.Slope))
 	argstr = append(argstr, fmt.Sprintf("--value=%s", conf.Value))

--- a/sinks/libgangliaSink.go
+++ b/sinks/libgangliaSink.go
@@ -124,24 +124,21 @@ func (s *LibgangliaSink) Write(point lp.CCMetric) error {
 		return s.cstrCache[key]
 	}
 
-	// Get metric name
-	metricname := GangliaMetricRename(point.Name())
-
 	conf := GetCommonGangliaConfig(point)
 	if len(conf.Type) == 0 {
 		conf = GetGangliaConfig(point)
 	}
 	if len(conf.Type) == 0 {
-		return fmt.Errorf("metric %s has no 'value' field", metricname)
+		return fmt.Errorf("metric %q (Ganglia name %q) has no 'value' field", point.Name(), conf.Name)
 	}
 
 	if s.config.AddTypeToName {
-		metricname = GangliaMetricName(point)
+		conf.Name = GangliaMetricName(point)
 	}
 
 	c_value = C.CString(conf.Value)
 	c_type = lookup(conf.Type)
-	c_name = lookup(metricname)
+	c_name = lookup(conf.Name)
 
 	// Add unit
 	unit := ""


### PR DESCRIPTION
When the router renames a metric, the original name is stored as meta information 'oldname'. Since Ganglia requires some metrics to have a specific name, the sinks check for the current and the old name of a metric.