### PR TITLE
Units with cc-units

### DIFF
--- a/collectors/netstatMetric.go
+++ b/collectors/netstatMetric.go
@@ -22,11 +22,12 @@ type NetstatCollectorConfig struct {
 }
 
 type NetstatCollectorMetric struct {
-	name      string
-	index     int
-	tags      map[string]string
-	rate_tags map[string]string
-	lastValue int64
+	name       string
+	index      int
+	tags       map[string]string
+	meta       map[string]string
+	meta_rates map[string]string
+	lastValue  int64
 }
 
 type NetstatCollector struct {
@@ -40,10 +41,6 @@ func (m *NetstatCollector) Init(config json.RawMessage) error {
 	m.name = "NetstatCollector"
 	m.setup()
 	m.lastTimestamp = time.Now()
-	m.meta = map[string]string{
-		"source": m.name,
-		"group":  "Network",
-	}
 
 	const (
 		fieldInterface = iota
@@ -104,39 +101,44 @@ func (m *NetstatCollector) Init(config json.RawMessage) error {
 
 		// Check if device is a included device
 		if _, ok := stringArrayContains(m.config.IncludeDevices, dev); ok {
-			tags_unit_byte := map[string]string{"device": dev, "type": "node", "unit": "bytes"}
-			tags_unit_byte_per_sec := map[string]string{"device": dev, "type": "node", "unit": "bytes/sec"}
-			tags_unit_pkts := map[string]string{"device": dev, "type": "node", "unit": "packets"}
-			tags_unit_pkts_per_sec := map[string]string{"device": dev, "type": "node", "unit": "packets/sec"}
+			tags := map[string]string{"device": dev, "type": "node"}
+			meta_unit_byte := map[string]string{"source": m.name, "group": "Network", "unit": "bytes"}
+			meta_unit_byte_per_sec := map[string]string{"source": m.name, "group": "Network", "unit": "bytes/sec"}
+			meta_unit_pkts := map[string]string{"source": m.name, "group": "Network", "unit": "packets"}
+			meta_unit_pkts_per_sec := map[string]string{"source": m.name, "group": "Network", "unit": "packets/sec"}
 
 			m.matches[dev] = []NetstatCollectorMetric{
 				{
-					name:      "net_bytes_in",
-					index:     fieldReceiveBytes,
-					lastValue: -1,
-					tags:      tags_unit_byte,
-					rate_tags: tags_unit_byte_per_sec,
+					name:       "net_bytes_in",
+					index:      fieldReceiveBytes,
+					lastValue:  -1,
+					tags:       tags,
+					meta:       meta_unit_byte,
+					meta_rates: meta_unit_byte_per_sec,
 				},
 				{
-					name:      "net_pkts_in",
-					index:     fieldReceivePackets,
-					lastValue: -1,
-					tags:      tags_unit_pkts,
-					rate_tags: tags_unit_pkts_per_sec,
+					name:       "net_pkts_in",
+					index:      fieldReceivePackets,
+					lastValue:  -1,
+					tags:       tags,
+					meta:       meta_unit_pkts,
+					meta_rates: meta_unit_pkts_per_sec,
 				},
 				{
-					name:      "net_bytes_out",
-					index:     fieldTransmitBytes,
-					lastValue: -1,
-					tags:      tags_unit_byte,
-					rate_tags: tags_unit_byte_per_sec,
+					name:       "net_bytes_out",
+					index:      fieldTransmitBytes,
+					lastValue:  -1,
+					tags:       tags,
+					meta:       meta_unit_byte,
+					meta_rates: meta_unit_byte_per_sec,
 				},
 				{
-					name:      "net_pkts_out",
-					index:     fieldTransmitPackets,
-					lastValue: -1,
-					tags:      tags_unit_pkts,
-					rate_tags: tags_unit_pkts_per_sec,
+					name:       "net_pkts_out",
+					index:      fieldTransmitPackets,
+					lastValue:  -1,
+					tags:       tags,
+					meta:       meta_unit_pkts,
+					meta_rates: meta_unit_pkts_per_sec,
 				},
 			}
 		}
@@ -194,14 +196,14 @@ func (m *NetstatCollector) Read(interval time.Duration, output chan lp.CCMetric)
 					continue
 				}
 				if m.config.SendAbsoluteValues {
-					if y, err := lp.New(metric.name, metric.tags, m.meta, map[string]interface{}{"value": v}, now); err == nil {
+					if y, err := lp.New(metric.name, metric.tags, metric.meta, map[string]interface{}{"value": v}, now); err == nil {
 						output <- y
 					}
 				}
 				if m.config.SendDerivedValues {
 					if metric.lastValue >= 0 {
 						rate := float64(v-metric.lastValue) / timeDiff
-						if y, err := lp.New(metric.name+"_bw", metric.rate_tags, m.meta, map[string]interface{}{"value": rate}, now); err == nil {
+						if y, err := lp.New(metric.name+"_bw", metric.tags, metric.meta_rates, map[string]interface{}{"value": rate}, now); err == nil {
 							output <- y
 						}
 					}

--- a/internal/metricRouter/README.md
+++ b/internal/metricRouter/README.md
@@ -8,6 +8,7 @@ The CCMetric router sits in between the collectors and the sinks and can be used
 {
     "num_cache_intervals" : 1,
     "interval_timestamp" : true,
+    "normalize_units": true,
     "add_tags" : [
         {
             "key" : "cluster",

--- a/internal/metricRouter/README.md
+++ b/internal/metricRouter/README.md
@@ -51,6 +51,11 @@ The CCMetric router sits in between the collectors and the sinks and can be used
     ],
     "rename_metrics" : {
         "metric_12345" : "mymetric"
+    },
+    "normalize_units" : true,
+    "change_unit_prefix" {
+      "mem_used" : "G",
+      "mem_total" : "G"
     }
 }
 ```
@@ -169,6 +174,13 @@ This option takes a list of evaluable conditions and performs them one after the
 ```
 The first line is comparable with the example in `drop_metrics`, it drops all metrics starting with `drop_metric_` and ending with a number. The second line drops all metrics of the first hardware thread (**not** recommended)
 
+
+## The `normalize_units` option
+The cc-metric-collector tries to read the data from the system as it is reported. If available, it tries to read the metric unit from the system as well (e.g. from `/proc/meminfo`). The problem is that, depending on the source, the metric units are named differently. Just think about `byte`, `Byte`, `B`, `bytes`, ...
+The [cc-units](https://github.com/ClusterCockpit/cc-units) package provides us a normalization option to use the same metric unit name for all metrics. It this option is set to true, all `unit` meta tags are normalized.
+
+## The `change_unit_prefix` section
+It is often the case that metrics are reported by the system using a rather outdated unit prefix (like `/proc/meminfo` still uses kByte despite current memory sizes are in the GByte range). If you want to change the prefix of a unit, you can do that with the help of [cc-units](https://github.com/ClusterCockpit/cc-units). The setting works on the metric name and requires the new prefix for the metric. The cc-units package determines the scaling factor.
 
 # Aggregate metric values of the current interval with the `interval_aggregates` option
 

--- a/internal/metricRouter/README.md
+++ b/internal/metricRouter/README.md
@@ -174,6 +174,7 @@ This option takes a list of evaluable conditions and performs them one after the
 ```
 The first line is comparable with the example in `drop_metrics`, it drops all metrics starting with `drop_metric_` and ending with a number. The second line drops all metrics of the first hardware thread (**not** recommended)
 
+# Manipulating the metric units
 
 ## The `normalize_units` option
 The cc-metric-collector tries to read the data from the system as it is reported. If available, it tries to read the metric unit from the system as well (e.g. from `/proc/meminfo`). The problem is that, depending on the source, the metric units are named differently. Just think about `byte`, `Byte`, `B`, `bytes`, ...
@@ -228,3 +229,22 @@ Use cases for `interval_aggregates`:
     }
   }
 ```
+
+# Order of operations
+
+The router performs the above mentioned options in a specific order. In order to get the logic you want for a specific metric, it is crucial to know the processing order:
+
+- Add the `hostname` tag (c)
+- Manipulate the timestamp to the interval timestamp (c,r)
+- Drop metrics based on `drop_metrics` and `drop_metrics_if` (c,r)
+- Add tags based on `add_tags` (c,r)
+- Delete tags based on `del_tags` (c,r)
+- Rename metric based on `rename_metric` (c,r)
+  - Add tags based on `add_tags` to still work if the configuration uses the new name (c,r) 
+  - Delete tags based on `del_tags` to still work if the configuration uses the new name (c,r)
+- Normalize units when `normalize_units` is set (c,r)
+- Convert unit prefix based on `change_unit_prefix` (c,r)
+
+Legend:
+- 'c' if metric is coming from a collector
+- 'r' if metric is coming from a receiver

--- a/internal/metricRouter/metricRouter.go
+++ b/internal/metricRouter/metricRouter.go
@@ -287,10 +287,10 @@ func (r *metricRouter) Start() {
 		if new, ok := r.config.RenameMetrics[name]; ok {
 			point.SetName(new)
 			point.AddMeta("oldname", name)
+			r.DoAddTags(point)
+			r.DoDelTags(point)
 		}
 
-		r.DoAddTags(point)
-		r.DoDelTags(point)
 		r.prepareUnit(point)
 
 		for _, o := range r.outputs {

--- a/internal/metricRouter/metricRouter.go
+++ b/internal/metricRouter/metricRouter.go
@@ -37,6 +37,7 @@ type metricRouterConfig struct {
 	NumCacheIntervals int                                  `json:"num_cache_intervals"` // Number of intervals of cached metrics for evaluation
 	MaxForward        int                                  `json:"max_forward"`         // Number of maximal forwarded metrics at one select
 	NormalizeUnits    bool                                 `json:"normalize_units"`     // Check unit meta flag and normalize it using cc-units
+	ChangeUnitPrefix  string                               `json:"change_unit_prefix"`  // Add prefix that should be applied to all metrics where possible
 	dropMetrics       map[string]bool                      // Internal map for O(1) lookup
 }
 
@@ -260,6 +261,55 @@ func (r *metricRouter) Start() {
 				u := units.NewUnit(in_unit)
 				if u.Valid() {
 					point.AddMeta("unit", u.Short())
+				}
+			}
+		}
+		if len(r.config.ChangeUnitPrefix) > 0 {
+			prefix := units.NewPrefix(r.config.ChangeUnitPrefix)
+			if prefix != units.InvalidPrefix {
+				if in_unit, ok := point.GetMeta("unit"); ok {
+					u := units.NewUnit(in_unit)
+					if u.Valid() {
+						conv, out_unit := units.GetUnitPrefixFactor(u, prefix)
+						if conv != nil && out_unit.Valid() {
+							if val, ok := point.GetField("value"); ok {
+								newval := 0.0
+								skip := false
+								switch v := val.(type) {
+								case float64:
+									newval = v
+								case float32:
+									newval = float64(v)
+								case int64:
+									newval = float64(v)
+								case int32:
+									newval = float64(v)
+								case int:
+									newval = float64(v)
+								case string:
+									skip = true
+								}
+								if !skip {
+									newval = conv(newval)
+									var x interface{}
+									switch val.(type) {
+									case float64:
+										x = newval
+									case float32:
+										x = float32(newval)
+									case int64:
+										x = int64(newval)
+									case int32:
+										x = int32(newval)
+									case int:
+										x = int(newval)
+									}
+									point.AddField("value", x)
+									point.AddMeta("unit", out_unit.Short())
+								}
+							}
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The metric router can be configured to
- [x] normalize units using https://github.com/ClusterCockpit/cc-units
- [x] convert metric values to same unit with different prefix (`kByte` -> `GByte`)
