### PR TITLE
Deprecated `ioutils`

### DIFF
--- a/collectors/beegfsmetaMetric.go
+++ b/collectors/beegfsmetaMetric.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"os/user"
@@ -115,7 +115,7 @@ func (m *BeegfsMetaCollector) Read(interval time.Duration, output chan lp.CCMetr
 		return
 	}
 	//get mounpoint
-	buffer, _ := ioutil.ReadFile(string("/proc/mounts"))
+	buffer, _ := os.ReadFile(string("/proc/mounts"))
 	mounts := strings.Split(string(buffer), "\n")
 	var mountpoints []string
 	for _, line := range mounts {
@@ -157,9 +157,9 @@ func (m *BeegfsMetaCollector) Read(interval time.Duration, output chan lp.CCMetr
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "BeegfsMetaCollector.Read(): Failed to execute command \"%s\": %s\n", cmd.String(), err.Error())
 			fmt.Fprintf(os.Stderr, "BeegfsMetaCollector.Read(): command exit code: \"%d\"\n", cmd.ProcessState.ExitCode())
-			data, _ := ioutil.ReadAll(cmdStderr)
+			data, _ := io.ReadAll(cmdStderr)
 			fmt.Fprintf(os.Stderr, "BeegfsMetaCollector.Read(): command stderr: \"%s\"\n", string(data))
-			data, _ = ioutil.ReadAll(cmdStdout)
+			data, _ = io.ReadAll(cmdStdout)
 			fmt.Fprintf(os.Stderr, "BeegfsMetaCollector.Read(): command stdout: \"%s\"\n", string(data))
 			return
 		}

--- a/collectors/beegfsstorageMetric.go
+++ b/collectors/beegfsstorageMetric.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"os/user"
@@ -108,7 +108,7 @@ func (m *BeegfsStorageCollector) Read(interval time.Duration, output chan lp.CCM
 		return
 	}
 	//get mounpoint
-	buffer, _ := ioutil.ReadFile(string("/proc/mounts"))
+	buffer, _ := os.ReadFile(string("/proc/mounts"))
 	mounts := strings.Split(string(buffer), "\n")
 	var mountpoints []string
 	for _, line := range mounts {
@@ -149,9 +149,9 @@ func (m *BeegfsStorageCollector) Read(interval time.Duration, output chan lp.CCM
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "BeegfsStorageCollector.Read(): Failed to execute command \"%s\": %s\n", cmd.String(), err.Error())
 			fmt.Fprintf(os.Stderr, "BeegfsStorageCollector.Read(): command exit code: \"%d\"\n", cmd.ProcessState.ExitCode())
-			data, _ := ioutil.ReadAll(cmdStderr)
+			data, _ := io.ReadAll(cmdStderr)
 			fmt.Fprintf(os.Stderr, "BeegfsStorageCollector.Read(): command stderr: \"%s\"\n", string(data))
-			data, _ = ioutil.ReadAll(cmdStdout)
+			data, _ = io.ReadAll(cmdStdout)
 			fmt.Fprintf(os.Stderr, "BeegfsStorageCollector.Read(): command stdout: \"%s\"\n", string(data))
 			return
 		}

--- a/collectors/cpufreqMetric.go
+++ b/collectors/cpufreqMetric.go
@@ -3,7 +3,7 @@ package collectors
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -88,7 +88,7 @@ func (m *CPUFreqCollector) Init(config json.RawMessage) error {
 
 		// Read package ID
 		physicalPackageIDFile := filepath.Join(cpuDir, "topology", "physical_package_id")
-		line, err := ioutil.ReadFile(physicalPackageIDFile)
+		line, err := os.ReadFile(physicalPackageIDFile)
 		if err != nil {
 			return fmt.Errorf("unable to read physical package ID from file '%s': %v", physicalPackageIDFile, err)
 		}
@@ -100,7 +100,7 @@ func (m *CPUFreqCollector) Init(config json.RawMessage) error {
 
 		// Read core ID
 		coreIDFile := filepath.Join(cpuDir, "topology", "core_id")
-		line, err = ioutil.ReadFile(coreIDFile)
+		line, err = os.ReadFile(coreIDFile)
 		if err != nil {
 			return fmt.Errorf("unable to read core ID from file '%s': %v", coreIDFile, err)
 		}
@@ -188,7 +188,7 @@ func (m *CPUFreqCollector) Read(interval time.Duration, output chan lp.CCMetric)
 		}
 
 		// Read current frequency
-		line, err := ioutil.ReadFile(t.scalingCurFreqFile)
+		line, err := os.ReadFile(t.scalingCurFreqFile)
 		if err != nil {
 			cclog.ComponentError(
 				m.name,

--- a/collectors/customCmdMetric.go
+++ b/collectors/customCmdMetric.go
@@ -3,8 +3,8 @@ package collectors
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"log"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -53,7 +53,7 @@ func (m *CustomCmdCollector) Init(config json.RawMessage) error {
 		}
 	}
 	for _, f := range m.config.Files {
-		_, err = ioutil.ReadFile(f)
+		_, err = os.ReadFile(f)
 		if err == nil {
 			m.files = append(m.files, f)
 		} else {
@@ -106,7 +106,7 @@ func (m *CustomCmdCollector) Read(interval time.Duration, output chan lp.CCMetri
 		}
 	}
 	for _, file := range m.files {
-		buffer, err := ioutil.ReadFile(file)
+		buffer, err := os.ReadFile(file)
 		if err != nil {
 			log.Print(err)
 			return

--- a/collectors/gpfsMetric.go
+++ b/collectors/gpfsMetric.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os/exec"
 	"os/user"
@@ -118,8 +118,8 @@ func (m *GpfsCollector) Read(interval time.Duration, output chan lp.CCMetric) {
 	cmd.Stderr = cmdStderr
 	err := cmd.Run()
 	if err != nil {
-		dataStdErr, _ := ioutil.ReadAll(cmdStderr)
-		dataStdOut, _ := ioutil.ReadAll(cmdStdout)
+		dataStdErr, _ := io.ReadAll(cmdStderr)
+		dataStdOut, _ := io.ReadAll(cmdStdout)
 		cclog.ComponentError(
 			m.name,
 			fmt.Sprintf("Read(): Failed to execute command \"%s\": %v\n", cmd.String(), err),

--- a/collectors/infinibandMetric.go
+++ b/collectors/infinibandMetric.go
@@ -2,7 +2,6 @@ package collectors
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	cclog "github.com/ClusterCockpit/cc-metric-collector/internal/ccLogger"
@@ -85,7 +84,7 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 	for _, path := range ibDirs {
 
 		// Skip, when no LID is assigned
-		line, err := ioutil.ReadFile(filepath.Join(path, "lid"))
+		line, err := os.ReadFile(filepath.Join(path, "lid"))
 		if err != nil {
 			continue
 		}
@@ -175,7 +174,7 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMetr
 		for counterName, counterDef := range info.portCounterFiles {
 
 			// Read counter file
-			line, err := ioutil.ReadFile(counterDef.path)
+			line, err := os.ReadFile(counterDef.path)
 			if err != nil {
 				cclog.ComponentError(
 					m.name,

--- a/collectors/likwidMetric.go
+++ b/collectors/likwidMetric.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"os/signal"
@@ -154,7 +153,7 @@ func getBaseFreq() float64 {
 	}
 	var freq float64 = math.NaN()
 	for _, f := range files {
-		buffer, err := ioutil.ReadFile(f)
+		buffer, err := os.ReadFile(f)
 		if err == nil {
 			data := strings.Replace(string(buffer), "\n", "", -1)
 			x, err := strconv.ParseInt(data, 0, 64)

--- a/collectors/loadavgMetric.go
+++ b/collectors/loadavgMetric.go
@@ -3,7 +3,7 @@ package collectors
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -72,7 +72,7 @@ func (m *LoadavgCollector) Read(interval time.Duration, output chan lp.CCMetric)
 	if !m.init {
 		return
 	}
-	buffer, err := ioutil.ReadFile(LOADAVGFILE)
+	buffer, err := os.ReadFile(LOADAVGFILE)
 	if err != nil {
 		if err != nil {
 			cclog.ComponentError(

--- a/collectors/tempMetric.go
+++ b/collectors/tempMetric.go
@@ -3,7 +3,7 @@ package collectors
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -83,14 +83,14 @@ func (m *TempCollector) Init(config json.RawMessage) error {
 
 		// sensor name
 		nameFile := filepath.Join(filepath.Dir(file), "name")
-		name, err := ioutil.ReadFile(nameFile)
+		name, err := os.ReadFile(nameFile)
 		if err == nil {
 			sensor.name = strings.TrimSpace(string(name))
 		}
 
 		// sensor label
 		labelFile := strings.TrimSuffix(file, "_input") + "_label"
-		label, err := ioutil.ReadFile(labelFile)
+		label, err := os.ReadFile(labelFile)
 		if err == nil {
 			sensor.label = strings.TrimSpace(string(label))
 		}
@@ -117,7 +117,7 @@ func (m *TempCollector) Init(config json.RawMessage) error {
 		}
 
 		// Sensor file
-		_, err = ioutil.ReadFile(file)
+		_, err = os.ReadFile(file)
 		if err != nil {
 			continue
 		}
@@ -139,7 +139,7 @@ func (m *TempCollector) Init(config json.RawMessage) error {
 		// max temperature
 		if m.config.ReportMaxTemp {
 			maxTempFile := strings.TrimSuffix(file, "_input") + "_max"
-			if buffer, err := ioutil.ReadFile(maxTempFile); err == nil {
+			if buffer, err := os.ReadFile(maxTempFile); err == nil {
 				if x, err := strconv.ParseInt(strings.TrimSpace(string(buffer)), 10, 64); err == nil {
 					sensor.maxTempName = strings.Replace(sensor.metricName, "temp", "max_temp", 1)
 					sensor.maxTemp = x / 1000
@@ -150,7 +150,7 @@ func (m *TempCollector) Init(config json.RawMessage) error {
 		// critical temperature
 		if m.config.ReportCriticalTemp {
 			criticalTempFile := strings.TrimSuffix(file, "_input") + "_crit"
-			if buffer, err := ioutil.ReadFile(criticalTempFile); err == nil {
+			if buffer, err := os.ReadFile(criticalTempFile); err == nil {
 				if x, err := strconv.ParseInt(strings.TrimSpace(string(buffer)), 10, 64); err == nil {
 					sensor.critTempName = strings.Replace(sensor.metricName, "temp", "crit_temp", 1)
 					sensor.critTemp = x / 1000
@@ -175,7 +175,7 @@ func (m *TempCollector) Read(interval time.Duration, output chan lp.CCMetric) {
 
 	for _, sensor := range m.sensors {
 		// Read sensor file
-		buffer, err := ioutil.ReadFile(sensor.file)
+		buffer, err := os.ReadFile(sensor.file)
 		if err != nil {
 			cclog.ComponentError(
 				m.name,


### PR DESCRIPTION
- replace `ioutils.ReadFile()` with `os.ReadFile()`
- replace `ioutisl.ReadAll()` with `io.ReadAll()`