### PR TITLE
Fix %sysusers_create_package args

### DIFF
--- a/scripts/cc-metric-collector.spec
+++ b/scripts/cc-metric-collector.spec
@@ -44,7 +44,7 @@ install -Dpm 0644 scripts/%{name}.sysusers %{buildroot}%{_sysusersdir}/%{name}.c
 # go test should be here... :)
 
 %pre
-%sysusers_create_package scripts/%{name}.sysusers
+%sysusers_create_package %{name} scripts/%{name}.sysusers
 
 %post
 %systemd_post %{name}.service


### PR DESCRIPTION
`%sysusers_create_package` requires two arguments. See: https://github.com/systemd/systemd/blob/main/src/rpm/macros.systemd.in#L165

I don't know how this could work before, but under EL9 the package doesn't build otherwise.