### PR TITLE
Little fixes to the prometheus sink

### DIFF
--- a/sinks/prometheusSink.go
+++ b/sinks/prometheusSink.go
@@ -49,6 +49,8 @@ func intToFloat64(input interface{}) (float64, error) {
 		return float64(value), nil
 	case int64:
 		return float64(value), nil
+	case uint64:
+		return float64(value), nil
 	}
 	return 0, errors.New("cannot cast value to float64")
 }

--- a/sinks/sinkManager.go
+++ b/sinks/sinkManager.go
@@ -21,6 +21,7 @@ var AvailableSinks = map[string]func(name string, config json.RawMessage) (Sink,
 	"influxdb":    NewInfluxSink,
 	"influxasync": NewInfluxAsyncSink,
 	"http":        NewHttpSink,
+	"prometheus":  NewPrometheusSink,
 }
 
 // Metric collector manager data structure


### PR DESCRIPTION
1. Nvlink error counters are unsigned integers, this option was missing in the cast method
2. Prometheus was no available sink although the code was there
3. NVlink errors are gathered by gpu and link. The prometheus exporter did not recognize the link id and therefore only reports the last link of each gpu. For our case, the sum of all links per gpu is the interesting value. So we implement this as a seperate metric.