### PR TITLE
Fix excluded metrics for diskstat and add exclude_mounts

### DIFF
--- a/collectors/diskstatMetric.md
+++ b/collectors/diskstatMetric.md
@@ -6,10 +6,13 @@
     "exclude_metrics": [
       "disk_total"
     ],
+    "exclude_mounts": [
+      "slurm-tmpfs"
+    ]
   }
 ```
 
-The `diskstat` collector reads data from `/proc/self/mounts` and outputs a handful **node** metrics. If a metric is not required, it can be excluded from forwarding it to the sink.
+The `diskstat` collector reads data from `/proc/self/mounts` and outputs a handful **node** metrics. If a metric is not required, it can be excluded from forwarding it to the sink. Additionally, any mount point containing one of the strings specified in `exclude_mounts` will be skipped during metric collection.
 
 Metrics per device (with `device` tag):
 * `disk_total` (unit `GBytes`)

--- a/receivers/natsReceiver.go
+++ b/receivers/natsReceiver.go
@@ -91,17 +91,18 @@ func (r *NatsReceiver) _NatsReceive(m *nats.Msg) {
 				return
 			}
 
-			y, _ := lp.NewMessage(
+			y, err := lp.NewMessage(
 				string(measurement),
 				tags,
 				nil,
 				fields,
 				t,
 			)
-
-			m, err := r.mp.ProcessMessage(y)
-			if err == nil && m != nil {
-				r.sink <- m
+			if err == nil {
+				m, err := r.mp.ProcessMessage(y)
+				if err == nil && m != nil && r.sink != nil {
+					r.sink <- m
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Until now the excluded_metrics from collectors.json was ignored.

Also this PR adds a new field, `exclude_mounts` that exclude all mount point containing the strings in the field. (our use case is the user specific /tmp dir from [job_container/tmpfs](https://slurm.schedmd.com/job_container_tmpfs.html))