### PR TITLE
Add derived values for nfsiostat

### DIFF
--- a/collectors/nfsiostatMetric.md
+++ b/collectors/nfsiostatMetric.md
@@ -3,16 +3,18 @@
 ```json
   "nfsiostat": {
     "exclude_metrics": [
-      "nfsio_oread"
+      "oread", "pageread"
     ],
-    "exclude_filesystems" : [
-        "/mnt",
+    "exclude_filesystems": [
+      "/mnt"
     ],
-    "use_server_as_stype": false
+    "use_server_as_stype": false,
+    "send_abs_values": false,
+    "send_derived_values": true
   }
 ```
 
-The `nfsiostat` collector reads data from `/proc/self/mountstats` and outputs a handful **node** metrics for each NFS filesystem. If a metric or filesystem is not required, it can be excluded from forwarding it to the sink.
+The `nfsiostat` collector reads data from `/proc/self/mountstats` and outputs a handful **node** metrics for each NFS filesystem. If a metric or filesystem is not required, it can be excluded from forwarding it to the sink. **Note:** When excluding metrics, you must provide the base metric name (e.g. pageread) without the nfsio_ prefix. This exclusion applies to both absolute and derived values.
 
 Metrics:
 * `nfsio_nread`: Bytes transferred by normal `read()` calls
@@ -23,5 +25,10 @@ Metrics:
 * `nfsio_pagewrite`: Pages transferred by `write()` calls
 * `nfsio_nfsread`: Bytes transferred for reading from the server
 * `nfsio_nfswrite`: Pages transferred by writing to the server
+
+For each of these, if derived values are enabled, an additional metric is sent with the `_bw` suffix, which represents the rate:
+
+  * For normal byte metrics: `unit=bytes/sec`
+  * For page metrics: `unit=4K_pages/s`
 
 The `nfsiostat` collector adds the mountpoint to the tags as `stype=filesystem,stype-id=<mountpoint>`. If the server address should be used instead of the mountpoint, use the `use_server_as_stype` config setting.

--- a/receivers/natsReceiver.go
+++ b/receivers/natsReceiver.go
@@ -91,17 +91,18 @@ func (r *NatsReceiver) _NatsReceive(m *nats.Msg) {
 				return
 			}
 
-			y, _ := lp.NewMessage(
+			y, err := lp.NewMessage(
 				string(measurement),
 				tags,
 				nil,
 				fields,
 				t,
 			)
-
-			m, err := r.mp.ProcessMessage(y)
-			if err == nil && m != nil {
-				r.sink <- m
+			if err == nil {
+				m, err := r.mp.ProcessMessage(y)
+				if err == nil && m != nil && r.sink != nil {
+					r.sink <- m
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR adds derived_values in Bytes/s and 4K_Pages/s to nfsiostat, similar to netstat.

Also the naming scheme for excluding metrics is clarified in the md file.