### PR TITLE
Introduce `only_metrics` filtering with bugfixes and enhancements

### DIFF
--- a/collectors/README.md
+++ b/collectors/README.md
@@ -16,30 +16,44 @@ In contrast to the configuration files for sinks and receivers, the collectors c
 
 # Available collectors
 
-* [`cpustat`](./cpustatMetric.md)
-* [`memstat`](./memstatMetric.md)
-* [`iostat`](./iostatMetric.md)
-* [`diskstat`](./diskstatMetric.md)
-* [`loadavg`](./loadavgMetric.md)
-* [`netstat`](./netstatMetric.md)
-* [`ibstat`](./infinibandMetric.md)
-* [`ibstat_perfquery`](./infinibandPerfQueryMetric.md)
-* [`tempstat`](./tempMetric.md)
-* [`lustrestat`](./lustreMetric.md)
-* [`likwid`](./likwidMetric.md)
-* [`nvidia`](./nvidiaMetric.md)
-* [`customcmd`](./customCmdMetric.md)
-* [`ipmistat`](./ipmiMetric.md)
-* [`topprocs`](./topprocsMetric.md)
-* [`nfs3stat`](./nfs3Metric.md)
-* [`nfs4stat`](./nfs4Metric.md)
-* [`cpufreq`](./cpufreqMetric.md)
-* [`cpufreq_cpuinfo`](./cpufreqCpuinfoMetric.md)
-* [`numastats`](./numastatsMetric.md)
-* [`gpfs`](./gpfsMetric.md)
-* [`beegfs_meta`](./beegfsmetaMetric.md)
-* [`beegfs_storage`](./beegfsstorageMetric.md)
-* [`rocm_smi`](./rocmsmiMetric.md)
+**CPU & Performance**
+* [`loadavg`](./loadavgMetric.md) - System load averages
+* [`cpustat`](./cpustatMetric.md) - CPU usage metrics
+* [`cpufreq`](./cpufreqMetric.md) - CPU frequency data
+* [`cpufreq_cpuinfo`](./cpufreqCpuinfoMetric.md) - CPU frequency from cpuinfo
+* [`likwid`](./likwidMetric.md) - Hardware performance via Likwid
+* [`topprocs`](./topprocsMetric.md) - Top process details
+
+**Memory**
+* [`memstat`](./memstatMetric.md) - Memory usage data
+* [`numastats`](./numastatsMetric.md) - NUMA memory allocations
+
+**Disk & I/O**
+* [`diskstat`](./diskstatMetric.md) - Disk usage metrics
+* [`iostat`](./iostatMetric.md) - I/O performance data
+
+**Filesystems**
+* [`beegfs_meta`](./beegfsmetaMetric.md) - BeeGFS metadata metrics
+* [`beegfs_storage`](./beegfsstorageMetric.md) - BeeGFS storage metrics
+* [`gpfs`](./gpfsMetric.md) - GPFS filesystem data
+* [`lustrestat`](./lustreMetric.md) - Lustre filesystem metrics
+* [`nfs3stat`](./nfs3Metric.md) - NFSv3 usage
+* [`nfs4stat`](./nfs4Metric.md) - NFSv4 usage
+
+**Network**
+* [`ibstat`](./infinibandMetric.md) - InfiniBand network metrics
+* [`netstat`](./netstatMetric.md) - Network interface data
+
+**GPU & Accelerators**
+* [`nvidia`](./nvidiaMetric.md) - NVIDIA GPU metrics
+* [`rocm_smi`](./rocmsmiMetric.md) - AMD ROCm SMI data
+
+**Hardware Monitoring**
+* [`ipmistat`](./ipmiMetric.md) - IPMI sensor readings
+* [`tempstat`](./tempMetric.md) - Temperature measurements
+
+**Custom**
+* [`customcmd`](./customCmdMetric.md) - Custom command output
 
 ## Todos
 

--- a/collectors/beegfsmetaMetric.go
+++ b/collectors/beegfsmetaMetric.go
@@ -14,8 +14,8 @@ import (
 	"strings"
 	"time"
 
+	lp "github.com/ClusterCockpit/cc-lib/pkg/ccMessage"
 	cclog "github.com/ClusterCockpit/cc-metric-collector/pkg/ccLogger"
-	lp "github.com/ClusterCockpit/cc-energy-manager/pkg/cc-message"
 )
 
 const DEFAULT_BEEGFS_CMD = "beegfs-ctl"

--- a/collectors/beegfsmetaMetric.md
+++ b/collectors/beegfsmetaMetric.md
@@ -26,50 +26,50 @@ in the configuration.
 
 When using the `exclude_metrics` option, the excluded metrics are summed as `other`.
 
-Important: The metrics listed below, are similar to the naming of BeeGFS. The Collector prefixes these with `beegfs_cstorage`(beegfs client storage).
+Important: The metrics listed below are similar to the naming of BeeGFS. The Collector prefixes these with `beegfs_cstorage`(beegfs client storage).
 
-For example beegfs metric `open`-> `beegfs_cstorage_open`
+For example `beegfs` metric `open`-> `beegfs_cstorage_open`
 
 Available Metrics:
 
-* sum
-* ack
-* close
-* entInf
-* fndOwn
-* mkdir
-* create
-* rddir
-* refrEnt
-* mdsInf
-* rmdir
-* rmLnk
-* mvDirIns
-* mvFiIns
-* open
-* ren
-* sChDrct
-* sAttr
-* sDirPat
-* stat
-* statfs
-* trunc
-* symlnk
-* unlnk
-* lookLI
-* statLI
-* revalLI
-* openLI
-* createLI
-* hardlnk
-* flckAp
-* flckEn
-* flckRg
-* dirparent
-* listXA
-* getXA
-* rmXA
-* setXA
-* mirror
+- sum
+- ack
+- close
+- entInf
+- fndOwn
+- mkdir
+- create
+- rddir
+- refrEnt
+- mdsInf
+- rmdir
+- rmLnk
+- mvDirIns
+- mvFiIns
+- open
+- ren
+- sChDrct
+- sAttr
+- sDirPat
+- stat
+- statfs
+- trunc
+- symlnk
+- unlnk
+- lookLI
+- statLI
+- revalLI
+- openLI
+- createLI
+- hardlnk
+- flckAp
+- flckEn
+- flckRg
+- dirparent
+- listXA
+- getXA
+- rmXA
+- setXA
+- mirror
 
 The collector adds a `filesystem` tag to all metrics

--- a/collectors/beegfsstorageMetric.go
+++ b/collectors/beegfsstorageMetric.go
@@ -14,8 +14,8 @@ import (
 	"strings"
 	"time"
 
+	lp "github.com/ClusterCockpit/cc-lib/pkg/ccMessage"
 	cclog "github.com/ClusterCockpit/cc-metric-collector/pkg/ccLogger"
-	lp "github.com/ClusterCockpit/cc-energy-manager/pkg/cc-message"
 )
 
 // Struct for the collector-specific JSON config

--- a/collectors/beegfsstorageMetric.md
+++ b/collectors/beegfsstorageMetric.md
@@ -25,31 +25,30 @@ in the configuration.
 
 When using the `exclude_metrics` option, the excluded metrics are summed as `other`.
 
-Important: The metrics listed below, are similar to the naming of BeeGFS. The Collector prefixes these with `beegfs_cstorage_`(beegfs client meta).
-For example beegfs metric `open`-> `beegfs_cstorage_`
+Important: The metrics listed below are similar to the naming of BeeGFS. The Collector prefixes these with `beegfs_cstorage_`(beegfs client meta).
+For example beegfs metric `open`-> `beegfs_cstorage_open`
 
-Note: BeeGFS FS offers many Metadata Information. Probably it makes sense to exlcude most of them. Nevertheless, these excluded metrics will be summed as `beegfs_cstorage_other`. 
+Note: BeeGFS FS offers many Metadata Information. Probably it makes sense to exclude most of them. Nevertheless, these excluded metrics will be summed as `beegfs_cstorage_other`.
 
 Available Metrics:
 
-* "sum"
-* "ack"
-* "sChDrct" 
-* "getFSize"
-* "sAttr"
-* "statfs"
-* "trunc"
-* "close"
-* "fsync"
-* "ops-rd"
-* "MiB-rd/s" 
-* "ops-wr"
-* "MiB-wr/s" 
-* "endbg" 
-* "hrtbeat"
-* "remNode"
-* "storInf"
-* "unlnk"
-
+- "sum"
+- "ack"
+- "sChDrct" 
+- "getFSize"
+- "sAttr"
+- "statfs"
+- "trunc"
+- "close"
+- "fsync"
+- "ops-rd"
+- "MiB-rd/s" 
+- "ops-wr"
+- "MiB-wr/s" 
+- "endbg" 
+- "hrtbeat"
+- "remNode"
+- "storInf"
+- "unlnk"
 
 The collector adds a `filesystem` tag to all metrics

--- a/collectors/collectorManager.go
+++ b/collectors/collectorManager.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	lp "github.com/ClusterCockpit/cc-energy-manager/pkg/cc-message"
+	lp "github.com/ClusterCockpit/cc-lib/pkg/ccMessage"
 	cclog "github.com/ClusterCockpit/cc-metric-collector/pkg/ccLogger"
 	mct "github.com/ClusterCockpit/cc-metric-collector/pkg/multiChanTicker"
 )

--- a/collectors/cpufreqCpuinfoMetric.md
+++ b/collectors/cpufreqCpuinfoMetric.md
@@ -4,8 +4,8 @@
   "cpufreq_cpuinfo": {}
 ```
 
-The `cpufreq_cpuinfo` collector reads the clock frequency from `/proc/cpuinfo` and outputs a handful **hwthread** metrics.
+The `cpufreq_cpuinfo` collector reads the clock frequency from `/proc/cpuinfo` and outputs `cpufreq` as a **hwthread** metric.
 
-Metrics:
+Metric:
 
-* `cpufreq`
+- `cpufreq`

--- a/collectors/cpufreqMetric.md
+++ b/collectors/cpufreqMetric.md
@@ -1,13 +1,11 @@
-## `cpufreq_cpuinfo` collector
+## `cpufreq` collector
 
 ```json
-  "cpufreq": {
-    "exclude_metrics": []
-  }
+  "cpufreq": {}
 ```
 
-The `cpufreq` collector reads the clock frequency from `/sys/devices/system/cpu/cpu*/cpufreq` and outputs a handful **hwthread** metrics.
+The `cpufreq` collector reads the clock frequency from `/sys/devices/system/cpu/cpu*/cpufreq` and outputs `cpufreq` as a **hwthread** metric.
 
-Metrics:
+Metric:
 
-* `cpufreq`
+- `cpufreq`

--- a/collectors/cpustatMetric.md
+++ b/collectors/cpustatMetric.md
@@ -1,27 +1,33 @@
-
 ## `cpustat` collector
 
 ```json
   "cpustat": {
     "exclude_metrics": [
       "cpu_idle"
+    ],
+    "only_metrics": [
+      "cpu_user"
     ]
   }
 ```
 
-The `cpustat` collector reads data from `/proc/stat` and outputs a handful **node** and **hwthread** metrics. If a metric is not required, it can be excluded from forwarding it to the sink.
+The `cpustat` collector reads data from `/proc/stat` and outputs a handful **node** and **hwthread** metrics.
+
+Both filtering mechanisms are supported:
+- `exclude_metrics`: Excludes the specified metrics.
+- `only_metrics`: If provided, only the listed metrics are collected. This takes precedence over `exclude_metrics`.
 
 Metrics:
 
-* `cpu_user` with `unit=Percent`
-* `cpu_nice` with `unit=Percent`
-* `cpu_system` with `unit=Percent`
-* `cpu_idle` with `unit=Percent`
-* `cpu_iowait` with `unit=Percent`
-* `cpu_irq` with `unit=Percent`
-* `cpu_softirq` with `unit=Percent`
-* `cpu_steal` with `unit=Percent`
-* `cpu_guest` with `unit=Percent`
-* `cpu_guest_nice` with `unit=Percent`
-* `cpu_used` = `cpu_* - cpu_idle` with `unit=Percent`
-* `num_cpus`
+- `cpu_user` (unit: `Percent`)
+- `cpu_nice` (unit: `Percent`)
+- `cpu_system` (unit: `Percent`)
+- `cpu_idle` (unit: `Percent`)
+- `cpu_iowait` (unit: `Percent`)
+- `cpu_irq` (unit: `Percent`)
+- `cpu_softirq` (unit: `Percent`)
+- `cpu_steal` (unit: `Percent`)
+- `cpu_guest` (unit: `Percent`)
+- `cpu_guest_nice` (unit: `Percent`)
+- `cpu_used` = `cpu_* - cpu_idle` (unit: `Percent`)
+- `num_cpus`

--- a/collectors/customCmdMetric.go
+++ b/collectors/customCmdMetric.go
@@ -9,25 +9,67 @@ import (
 	"strings"
 	"time"
 
-	lp "github.com/ClusterCockpit/cc-energy-manager/pkg/cc-message"
+	lp "github.com/ClusterCockpit/cc-lib/ccMessage"
 	influx "github.com/influxdata/line-protocol"
 )
 
 const CUSTOMCMDPATH = `/home/unrz139/Work/cc-metric-collector/collectors/custom`
 
 type CustomCmdCollectorConfig struct {
-	Commands       []string `json:"commands"`
-	Files          []string `json:"files"`
-	ExcludeMetrics []string `json:"exclude_metrics"`
+	Commands           []string `json:"commands"`
+	Files              []string `json:"files"`
+	ExcludeMetrics     []string `json:"exclude_metrics"`
+	OnlyMetrics        []string `json:"only_metrics,omitempty"`
+	SendAbsoluteValues *bool    `json:"send_abs_values,omitempty"`
+	SendDiffValues     *bool    `json:"send_diff_values,omitempty"`
+	SendDerivedValues  *bool    `json:"send_derived_values,omitempty"`
+}
+
+// set default values: send_abs_values: true, send_diff_values: false, send_derived_values: false.
+func (cfg *CustomCmdCollectorConfig) AbsValues() bool {
+	if cfg.SendAbsoluteValues == nil {
+		return true
+	}
+	return *cfg.SendAbsoluteValues
+}
+func (cfg *CustomCmdCollectorConfig) DiffValues() bool {
+	if cfg.SendDiffValues == nil {
+		return false
+	}
+	return *cfg.SendDiffValues
+}
+func (cfg *CustomCmdCollectorConfig) DerivedValues() bool {
+	if cfg.SendDerivedValues == nil {
+		return false
+	}
+	return *cfg.SendDerivedValues
 }
 
 type CustomCmdCollector struct {
 	metricCollector
-	handler  *influx.MetricHandler
-	parser   *influx.Parser
-	config   CustomCmdCollectorConfig
-	commands []string
-	files    []string
+	handler   *influx.MetricHandler
+	parser    *influx.Parser
+	config    CustomCmdCollectorConfig
+	commands  []string
+	files     []string
+	oldValues map[string]float64
+}
+
+func (m *CustomCmdCollector) shouldOutput(metricName string) bool {
+	if len(m.config.OnlyMetrics) > 0 {
+		for _, name := range m.config.OnlyMetrics {
+			if name == metricName {
+				return true
+			}
+		}
+		return false
+	}
+	for _, name := range m.config.ExcludeMetrics {
+		if name == metricName {
+			return false
+		}
+	}
+	return true
 }
 
 func (m *CustomCmdCollector) Init(config json.RawMessage) error {
@@ -67,6 +109,7 @@ func (m *CustomCmdCollector) Init(config json.RawMessage) error {
 	m.handler = influx.NewMetricHandler()
 	m.parser = influx.NewParser(m.handler)
 	m.parser.SetTimeFunc(DefaultTime)
+	m.oldValues = make(map[string]float64)
 	m.init = true
 	return nil
 }
@@ -75,6 +118,73 @@ var DefaultTime = func() time.Time {
 	return time.Unix(42, 0)
 }
 
+// copyMeta creates a deep copy of a map[string]string.
+func copyMeta(orig map[string]string) map[string]string {
+	newMeta := make(map[string]string)
+	for k, v := range orig {
+		newMeta[k] = v
+	}
+	return newMeta
+}
+
+// getMetricValueFromMsg extracts the numeric "value" field from a CCMessage.
+func getMetricValueFromMsg(msg lp.CCMessage) (float64, bool) {
+	fields := msg.Fields()
+	if v, ok := fields["value"]; ok {
+		if num, ok := v.(float64); ok {
+			return num, true
+		}
+	}
+	return 0, false
+}
+
+// processMetric processes a single metric:
+// - If send_abs_values is enabled, sends the absolute metric.
+// - If send_diff_values is enabled and a previous value exists, sends the diff value under the name "<base>_diff".
+// - If send_derived_values is enabled and a previous value exists, sends the derived rate as "<base>_rate".
+func (m *CustomCmdCollector) processMetric(msg lp.CCMessage, interval time.Duration, output chan lp.CCMessage) {
+	name := msg.Name()
+	if !m.shouldOutput(name) {
+		return
+	}
+	if m.config.AbsValues() {
+		output <- msg
+	}
+	val, ok := getMetricValueFromMsg(msg)
+	if !ok {
+		return
+	}
+	if prev, exists := m.oldValues[name]; exists {
+		diff := val - prev
+		if m.config.DiffValues() && m.shouldOutput(name+"_diff") {
+			diffMsg, err := lp.NewMessage(name+"_diff", msg.Tags(), msg.Meta(), map[string]interface{}{"value": diff}, time.Now())
+			if err == nil {
+				output <- diffMsg
+			}
+		}
+		if m.config.DerivedValues() && m.shouldOutput(name+"_rate") {
+			derived := diff / interval.Seconds()
+			newMeta := copyMeta(msg.Meta())
+			unit := newMeta["unit"]
+			if unit == "" {
+				if tagUnit, ok := msg.Tags()["unit"]; ok {
+					unit = tagUnit
+					newMeta["unit"] = unit
+				}
+			}
+			if unit != "" && !strings.HasSuffix(unit, "/s") {
+				newMeta["unit"] = unit + "/s"
+			}
+			derivedMsg, err := lp.NewMessage(name+"_rate", msg.Tags(), newMeta, map[string]interface{}{"value": derived}, time.Now())
+			if err == nil {
+				output <- derivedMsg
+			}
+		}
+	}
+	m.oldValues[name] = val
+}
+
+// Read processes commands and files, parses their output, and processes each metric.
 func (m *CustomCmdCollector) Read(interval time.Duration, output chan lp.CCMessage) {
 	if !m.init {
 		return
@@ -88,37 +198,30 @@ func (m *CustomCmdCollector) Read(interval time.Duration, output chan lp.CCMessa
 			log.Print(err)
 			continue
 		}
-		cmdmetrics, err := m.parser.Parse(stdout)
+		metrics, err := m.parser.Parse(stdout)
 		if err != nil {
 			log.Print(err)
 			continue
 		}
-		for _, c := range cmdmetrics {
-			_, skip := stringArrayContains(m.config.ExcludeMetrics, c.Name())
-			if skip {
-				continue
-			}
-
-			output <- lp.FromInfluxMetric(c)
+		for _, met := range metrics {
+			msg := lp.FromInfluxMetric(met)
+			m.processMetric(msg, interval, output)
 		}
 	}
 	for _, file := range m.files {
 		buffer, err := os.ReadFile(file)
 		if err != nil {
 			log.Print(err)
-			return
+			continue
 		}
-		fmetrics, err := m.parser.Parse(buffer)
+		metrics, err := m.parser.Parse(buffer)
 		if err != nil {
 			log.Print(err)
 			continue
 		}
-		for _, f := range fmetrics {
-			_, skip := stringArrayContains(m.config.ExcludeMetrics, f.Name())
-			if skip {
-				continue
-			}
-			output <- lp.FromInfluxMetric(f)
+		for _, met := range metrics {
+			msg := lp.FromInfluxMetric(met)
+			m.processMetric(msg, interval, output)
 		}
 	}
 }

--- a/collectors/customCmdMetric.md
+++ b/collectors/customCmdMetric.md
@@ -36,12 +36,12 @@ mem_usage,host=myhost,type=node,unit=MByte value=1024 1670000000000000000
 The following tags are commonly used:
 - **type:** Indicates the metric scope, e.g. "node", "socket" or "hwthread".
 - **type-id:** The identifier for the type (e.g. the specific hardware thread or socket).
-- **unit:** The unit of the metric (e.g. "MByte").  
+- **unit:** The unit of the metric (e.g. "MByte").
 
 For each metric parsed from the output:
 - If `send_abs_values` is enabled, the **absolute (raw) metric** is forwarded.
 - If `send_diff_values` is enabled and a previous value exists, the collector computes the **difference** (current value minus previous value) and forwards it as a new metric with the suffix `_diff`.
-- If `send_derived_values` is enabled and a previous value exists, the collector computes the **derived rate** (difference divided by the time interval) and forwards it as a new metric with the suffix `_rate`.  
+- If `send_derived_values` is enabled and a previous value exists, the collector computes the **derived rate** (difference divided by the time interval) and forwards it as a new metric with the suffix `_rate`.
   Additionally, if the original metric includes a unit (in its meta data or tags), the derived metric's unit is set to that unit with "/s" appended.
 
 Both filtering mechanisms are supported:

--- a/collectors/customCmdMetric.md
+++ b/collectors/customCmdMetric.md
@@ -1,4 +1,3 @@
-
 ## `customcmd` collector
 
 ```json
@@ -6,15 +5,45 @@
     "exclude_metrics": [
       "mymetric"
     ],
-    "files" : [
+    "only_metrics": [
+      "cpu_usage",
+      "cpu_usage_rate",
+      "mem_usage",
+      "mem_usage_rate"
+    ],
+    "send_abs_values": true,
+    "send_diff_values": true,
+    "send_derived_values": true,
+    "files": [
       "/var/run/myapp.metrics"
     ],
-    "commands" : [
+    "commands": [
       "/usr/local/bin/getmetrics.pl"
     ]
   }
 ```
 
-The `customcmd` collector reads data from files and the output of executed commands. The files and commands can output multiple metrics (separated by newline) but the have to be in the [InfluxDB line protocol](https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol/). If a metric is not parsable, it is skipped. If a metric is not required, it can be excluded from forwarding it to the sink.
+The `customcmd` collector reads data from specified files and executed commands.
+Both the output of commands and the content of files must follow the [InfluxDB line protocol](https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol/).
 
+**Expected format example:**
 
+```
+cpu_usage,host=myhost,type=hwthread,type-id=0,unit=MByte value=42.0 1670000000000000000
+mem_usage,host=myhost,type=node,unit=MByte value=1024 1670000000000000000
+```
+
+The following tags are commonly used:
+- **type:** Indicates the metric scope, e.g. "node", "socket" or "hwthread".
+- **type-id:** The identifier for the type (e.g. the specific hardware thread or socket).
+- **unit:** The unit of the metric (e.g. "MByte").  
+
+For each metric parsed from the output:
+- If `send_abs_values` is enabled, the **absolute (raw) metric** is forwarded.
+- If `send_diff_values` is enabled and a previous value exists, the collector computes the **difference** (current value minus previous value) and forwards it as a new metric with the suffix `_diff`.
+- If `send_derived_values` is enabled and a previous value exists, the collector computes the **derived rate** (difference divided by the time interval) and forwards it as a new metric with the suffix `_rate`.  
+  Additionally, if the original metric includes a unit (in its meta data or tags), the derived metric's unit is set to that unit with "/s" appended.
+
+Both filtering mechanisms are supported:
+- `exclude_metrics`: Excludes the specified metrics.
+- `only_metrics`: If provided, only the listed metrics are collected. This takes precedence over `exclude_metrics`.

--- a/collectors/diskstatMetric.md
+++ b/collectors/diskstatMetric.md
@@ -1,21 +1,29 @@
-
 ## `diskstat` collector
 
 ```json
   "diskstat": {
     "exclude_metrics": [
-      "disk_total"
+      "part_max_used"
     ],
+    "only_metrics": [
+      "disk_free",
+    ],
+    "exclude_mounts": [
+      "slurm-tmpfs"
+    ]
   }
 ```
 
-The `diskstat` collector reads data from `/proc/self/mounts` and outputs a handful **node** metrics. If a metric is not required, it can be excluded from forwarding it to the sink.
+The `diskstat` collector reads data from `/proc/self/mounts` and outputs a handful **node** metrics. 
+Any mount point containing one of the strings specified in `exclude_mounts` will be skipped during metric collection.
+
+Both filtering mechanisms are supported:
+- `exclude_metrics`: Excludes the specified metrics.
+- `only_metrics`: If provided, only the listed metrics are collected. This takes precedence over `exclude_metrics`.
 
 Metrics per device (with `device` tag):
-* `disk_total` (unit `GBytes`)
-* `disk_free` (unit `GBytes`)
+- `disk_total` (unit `GBytes`)
+- `disk_free` (unit `GBytes`)
 
 Global metrics:
-* `part_max_used` (unit `percent`)
-
-
+- `part_max_used` (unit `percent`)

--- a/collectors/gpfsMetric.go
+++ b/collectors/gpfsMetric.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"time"
 
+	lp "github.com/ClusterCockpit/cc-lib/pkg/ccMessage"
 	cclog "github.com/ClusterCockpit/cc-metric-collector/pkg/ccLogger"
-	lp "github.com/ClusterCockpit/cc-energy-manager/pkg/cc-message"
 )
 
 const DEFAULT_GPFS_CMD = "mmpmon"

--- a/collectors/gpfsMetric.md
+++ b/collectors/gpfsMetric.md
@@ -1,7 +1,7 @@
 ## `gpfs` collector
 
 ```json
-  "ibstat": {
+  "gpfs": {
     "mmpmon_path": "/path/to/mmpmon",
     "exclude_filesystem": [
       "fs1"
@@ -22,18 +22,18 @@ in the configuration. If nothing is set, the collector searches in `$PATH` for `
 
 
 Metrics:
-* `gpfs_bytes_read`
-* `gpfs_bytes_written`
-* `gpfs_num_opens`
-* `gpfs_num_closes`
-* `gpfs_num_reads`
-* `gpfs_num_writes`
-* `gpfs_num_readdirs`
-* `gpfs_num_inode_updates`
-* `gpfs_bytes_total = gpfs_bytes_read + gpfs_bytes_written` (if `send_total_values == true`)
-* `gpfs_iops = gpfs_num_reads + gpfs_num_writes` (if `send_total_values == true`)
-* `gpfs_metaops = gpfs_num_inode_updates + gpfs_num_closes + gpfs_num_opens + gpfs_num_readdirs` (if `send_total_values == true`)
-* `gpfs_bw_read` (if `send_bandwidths == true`)
-* `gpfs_bw_write` (if `send_bandwidths == true`)
+- `gpfs_bytes_read`
+- `gpfs_bytes_written`
+- `gpfs_num_opens`
+- `gpfs_num_closes`
+- `gpfs_num_reads`
+- `gpfs_num_writes`
+- `gpfs_num_readdirs`
+- `gpfs_num_inode_updates`
+- `gpfs_bytes_total = gpfs_bytes_read + gpfs_bytes_written` (if `send_total_values == true`)
+- `gpfs_iops = gpfs_num_reads + gpfs_num_writes` (if `send_total_values == true`)
+- `gpfs_metaops = gpfs_num_inode_updates + gpfs_num_closes + gpfs_num_opens + gpfs_num_readdirs` (if `send_total_values == true`)
+- `gpfs_bw_read` (if `send_bandwidths == true`)
+- `gpfs_bw_write` (if `send_bandwidths == true`)
 
 The collector adds a `filesystem` tag to all metrics

--- a/collectors/infinibandMetric.md
+++ b/collectors/infinibandMetric.md
@@ -1,4 +1,3 @@
-
 ## `ibstat` collector
 
 ```json
@@ -6,30 +5,41 @@
     "exclude_devices": [
       "mlx4"
     ],
+    "exclude_metrics": [
+      "ib_total"
+    ],
+    "only_metrics": [
+      "ib_revc_bw"
+    ],
     "send_abs_values": true,
-    "send_derived_values": true
+    "send_derived_values": true,
+    "send_total_values": true
   }
 ```
 
-The `ibstat` collector includes all Infiniband devices that can be
-found below `/sys/class/infiniband/` and where any of the ports provides a
-LID file (`/sys/class/infiniband/<dev>/ports/<port>/lid`)
-
-The devices can be filtered with the `exclude_devices` option in the configuration.
+The ibstat collector includes all InfiniBand devices found under `/sys/class/infiniband/` for which a LID file (`/sys/class/infiniband/<dev>/ports/<port>/lid`) is present.
+Devices can be filtered with the `exclude_devices` option.
 
 For each found LID the collector reads data through the sysfs files below `/sys/class/infiniband/<device>`. (See: <https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-class-infiniband>)
 
-Metrics:
+Both filtering mechanisms are supported:
+- `exclude_metrics`: Excludes the specified metrics.
+- `only_metrics`: If provided, only the listed metrics are collected. This takes precedence over `exclude_metrics`.
 
-* `ib_recv`
-* `ib_xmit`
-* `ib_recv_pkts`
-* `ib_xmit_pkts`
-* `ib_total = ib_recv + ib_xmit` (if `send_total_values == true`)
-* `ib_total_pkts = ib_recv_pkts + ib_xmit_pkts` (if `send_total_values == true`)
-* `ib_recv_bw` (if `send_derived_values == true`)
-* `ib_xmit_bw` (if `send_derived_values == true`)
-* `ib_recv_pkts_bw` (if `send_derived_values == true`)
-* `ib_xmit_pkts_bw` (if `send_derived_values == true`)
+**Absolute Metrics:**
+- `ib_recv` (unit: `bytes`)
+- `ib_xmit` (unit: `bytes`)
+- `ib_recv_pkts` (unit: `packets`)
+- `ib_xmit_pkts` (unit: `packets`)
+
+**Derived Metrics:**
+- `ib_recvi_bw` (unit: `bytes/s`)
+- `ib_xmit_bw` (unit: `bytes/s`)
+- `ib_recv_pkts_bw` (unit: `packets/s`)
+- `ib_xmit_pkts_bw` (unit: `packets/s`)
+
+**Global metrics** (if `send_total_values` is enabled):
+- `ib_total` = ib_recv + ib_xmit (unit: `bytes`)
+- `ib_total_pkts` = ib_recv_pkts + ib_xmit_pkts (unit: `packets`)
 
 The collector adds a `device` tag to all metrics

--- a/collectors/iostatMetric.md
+++ b/collectors/iostatMetric.md
@@ -1,34 +1,51 @@
-
 ## `iostat` collector
 
 ```json
   "iostat": {
     "exclude_metrics": [
-      "read_ms"
+      "io_read_ms"
     ],
+    "exclude_devices": [
+      "nvme0n1p1",
+      "nvme0n1p2",
+      "md127"
+    ],
+    "only_metrics": [],
+    "send_abs_values": true,
+    "send_diff_values": true,
+    "send_derived_values": true
   }
 ```
 
 The `iostat` collector reads data from `/proc/diskstats` and outputs a handful **node** metrics. If a metric is not required, it can be excluded from forwarding it to the sink.
 
-Metrics:
-* `io_reads`
-* `io_reads_merged`
-* `io_read_sectors`
-* `io_read_ms`
-* `io_writes`
-* `io_writes_merged`
-* `io_writes_sectors`
-* `io_writes_ms`
-* `io_ioops`
-* `io_ioops_ms`
-* `io_ioops_weighted_ms`
-* `io_discards`
-* `io_discards_merged`
-* `io_discards_sectors`
-* `io_discards_ms`
-* `io_flushes`
-* `io_flushes_ms`
+Both filtering mechanisms are supported:
+- `exclude_metrics`: Excludes the specified metrics.
+- `only_metrics`: If provided, only the listed metrics are collected. This takes precedence over `exclude_metrics`.
+
+**Absolute Metrics:**
+- `io_reads`
+- `io_reads_merged`
+- `io_read_sectors`
+- `io_read_ms`
+- `io_writes`
+- `io_writes_merged`
+- `io_writes_sectors`
+- `io_writes_ms`
+- `io_ioops`
+- `io_ioops_ms`
+- `io_ioops_weighted_ms`
+- `io_discards`
+- `io_discards_merged`
+- `io_discards_sectors`
+- `io_discards_ms`
+- `io_flushes`
+- `io_flushes_ms`
+
+**Diff Metrics:**
+For each metric, if `send_diff_values` is enabled, the collector computes the difference (current value minus previous value) and sends it with the suffix `_diff`.
+
+**Derived Metrics:**
+For each metric, if `send_derived_values` is enabled, the collector computes the derived rate (difference divided by the time interval) and sends it with the suffix `_rate`.
 
 The device name is added as tag `device`. For more details, see https://www.kernel.org/doc/html/latest/admin-guide/iostats.html
-

--- a/collectors/ipmiMetric.md
+++ b/collectors/ipmiMetric.md
@@ -1,13 +1,23 @@
-
 ## `ipmistat` collector
 
 ```json
   "ipmistat": {
     "ipmitool_path": "/path/to/ipmitool",
     "ipmisensors_path": "/path/to/ipmi-sensors",
+    "exclude_metrics": [
+      "cpu0_temp"
+    ],
+    "only_metrics": [
+      "sys_power",
+      "inlet_air_temp"
+    ]
   }
 ```
 
-The `ipmistat` collector reads data from `ipmitool` (`ipmitool sensor`) or `ipmi-sensors` (`ipmi-sensors --sdr-cache-recreate --comma-separated-output`).
+The `ipmistat` collector retrieves sensor data via IPMI. By default, if `ipmitool` is found in the system’s `PATH` and executes successfully with "-V", it is used to run `ipmitool sensor`. Only if `ipmitool` is not found or fails, the collector falls back to `ipmi-sensors` (executed with `--comma-separated-output --sdr-cache-recreate`).
+
+Both filtering mechanisms are supported:
+- `exclude_metrics`: Excludes the specified metrics.
+- `only_metrics`: If provided, only the listed metrics are collected. This takes precedence over `exclude_metrics`.
 
 The metrics depend on the output of the underlying tools but contain temperature, power and energy metrics.

--- a/collectors/likwidMetric.go
+++ b/collectors/likwidMetric.go
@@ -24,7 +24,7 @@ import (
 	"time"
 	"unsafe"
 
-	lp "github.com/ClusterCockpit/cc-energy-manager/pkg/cc-message"
+	lp "github.com/ClusterCockpit/cc-lib/ccMessage"
 	agg "github.com/ClusterCockpit/cc-metric-collector/internal/metricAggregator"
 	cclog "github.com/ClusterCockpit/cc-metric-collector/pkg/ccLogger"
 	topo "github.com/ClusterCockpit/cc-metric-collector/pkg/ccTopology"

--- a/collectors/likwidMetric.md
+++ b/collectors/likwidMetric.md
@@ -1,4 +1,3 @@
-
 ## `likwid` collector
 
 The `likwid` collector is probably the most complicated collector. The LIKWID library is included as static library with *direct* access mode. The *direct* access mode is suitable if the daemon is executed by a root user. The static library does not contain the performance groups, so all information needs to be provided in the configuration.
@@ -48,7 +47,7 @@ The `likwid` configuration consists of two parts, the `eventsets` and `globalmet
 Additional options:
 
 - `force_overwrite`: Same as setting `LIKWID_FORCE=1`. In case counters are already in-use, LIKWID overwrites their configuration to do its measurements
-- `invalid_to_zero`: In some cases, the calculations result in `NaN` or `Inf`. With this option, all `NaN` and `Inf` values are replaces with `0.0`. See below in [seperate section](./likwidMetric.md#invalid_to_zero-option)
+- `invalid_to_zero`: In some cases, the calculations result in `NaN` or `Inf`. With this option, all `NaN` and `Inf` values are replaced with `0.0`. See below in [seperate section](./likwidMetric.md#invalid_to_zero-option)
 - `access_mode`: Specify LIKWID access mode: `direct` for direct register access as root user or `accessdaemon`. The access mode `perf_event` is current untested.
 - `accessdaemon_path`: Folder of the accessDaemon `likwid-accessD` (like `/usr/local/sbin`)
 - `liblikwid_path`: Location of `liblikwid.so` including file name like `/usr/local/lib/liblikwid.so`

--- a/collectors/loadavgMetric.go
+++ b/collectors/loadavgMetric.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	lp "github.com/ClusterCockpit/cc-energy-manager/pkg/cc-message"
+	lp "github.com/ClusterCockpit/cc-lib/ccMessage"
 	cclog "github.com/ClusterCockpit/cc-metric-collector/pkg/ccLogger"
 )
 
@@ -22,14 +22,28 @@ const LOADAVGFILE = "/proc/loadavg"
 
 type LoadavgCollector struct {
 	metricCollector
-	tags         map[string]string
-	load_matches []string
-	load_skips   []bool
-	proc_matches []string
-	proc_skips   []bool
-	config       struct {
+	tags   map[string]string
+	config struct {
 		ExcludeMetrics []string `json:"exclude_metrics,omitempty"`
+		OnlyMetrics    []string `json:"only_metrics,omitempty"`
 	}
+}
+
+func (m *LoadavgCollector) shouldOutput(metricName string) bool {
+	if len(m.config.OnlyMetrics) > 0 {
+		for _, n := range m.config.OnlyMetrics {
+			if n == metricName {
+				return true
+			}
+		}
+		return false
+	}
+	for _, n := range m.config.ExcludeMetrics {
+		if n == metricName {
+			return false
+		}
+	}
+	return true
 }
 
 func (m *LoadavgCollector) Init(config json.RawMessage) error {
@@ -37,31 +51,12 @@ func (m *LoadavgCollector) Init(config json.RawMessage) error {
 	m.parallel = true
 	m.setup()
 	if len(config) > 0 {
-		err := json.Unmarshal(config, &m.config)
-		if err != nil {
+		if err := json.Unmarshal(config, &m.config); err != nil {
 			return err
 		}
 	}
-	m.meta = map[string]string{
-		"source": m.name,
-		"group":  "LOAD"}
+	m.meta = map[string]string{"source": m.name, "group": "LOAD"}
 	m.tags = map[string]string{"type": "node"}
-	m.load_matches = []string{
-		"load_one",
-		"load_five",
-		"load_fifteen"}
-	m.load_skips = make([]bool, len(m.load_matches))
-	m.proc_matches = []string{
-		"proc_run",
-		"proc_total"}
-	m.proc_skips = make([]bool, len(m.proc_matches))
-
-	for i, name := range m.load_matches {
-		_, m.load_skips[i] = stringArrayContains(m.config.ExcludeMetrics, name)
-	}
-	for i, name := range m.proc_matches {
-		_, m.proc_skips[i] = stringArrayContains(m.config.ExcludeMetrics, name)
-	}
 	m.init = true
 	return nil
 }
@@ -72,50 +67,43 @@ func (m *LoadavgCollector) Read(interval time.Duration, output chan lp.CCMessage
 	}
 	buffer, err := os.ReadFile(LOADAVGFILE)
 	if err != nil {
-		cclog.ComponentError(
-			m.name,
-			fmt.Sprintf("Read(): Failed to read file '%s': %v", LOADAVGFILE, err))
+		cclog.ComponentError(m.name, fmt.Sprintf("Read(): Failed to read file '%s': %v", LOADAVGFILE, err))
 		return
 	}
 	now := time.Now()
+	ls := strings.Split(string(buffer), " ")
 
 	// Load metrics
-	ls := strings.Split(string(buffer), ` `)
-	for i, name := range m.load_matches {
+	loadMetrics := []string{"load_one", "load_five", "load_fifteen"}
+	for i, name := range loadMetrics {
 		x, err := strconv.ParseFloat(ls[i], 64)
 		if err != nil {
-			cclog.ComponentError(
-				m.name,
-				fmt.Sprintf("Read(): Failed to convert '%s' to float64: %v", ls[i], err))
+			cclog.ComponentError(m.name, fmt.Sprintf("Read(): Failed to convert '%s' to float64: %v", ls[i], err))
 			continue
 		}
-		if m.load_skips[i] {
-			continue
-		}
-		y, err := lp.NewMessage(name, m.tags, m.meta, map[string]interface{}{"value": x}, now)
-		if err == nil {
-			output <- y
+		if m.shouldOutput(name) {
+			y, err := lp.NewMessage(name, m.tags, m.meta, map[string]interface{}{"value": x}, now)
+			if err == nil {
+				output <- y
+			}
 		}
 	}
 
 	// Process metrics
 	lv := strings.Split(ls[3], `/`)
-	for i, name := range m.proc_matches {
+	procMetrics := []string{"proc_run", "proc_total"}
+	for i, name := range procMetrics {
 		x, err := strconv.ParseInt(lv[i], 10, 64)
 		if err != nil {
-			cclog.ComponentError(
-				m.name,
-				fmt.Sprintf("Read(): Failed to convert '%s' to float64: %v", lv[i], err))
+			cclog.ComponentError(m.name, fmt.Sprintf("Read(): Failed to convert '%s' to int64: %v", lv[i], err))
 			continue
 		}
-		if m.proc_skips[i] {
-			continue
+		if m.shouldOutput(name) {
+			y, err := lp.NewMessage(name, m.tags, m.meta, map[string]interface{}{"value": x}, now)
+			if err == nil {
+				output <- y
+			}
 		}
-		y, err := lp.NewMessage(name, m.tags, m.meta, map[string]interface{}{"value": x}, now)
-		if err == nil {
-			output <- y
-		}
-
 	}
 }
 

--- a/collectors/loadavgMetric.md
+++ b/collectors/loadavgMetric.md
@@ -1,19 +1,26 @@
-
 ## `loadavg` collector
 
 ```json
   "loadavg": {
     "exclude_metrics": [
       "proc_run"
+    ],
+    "only_metrics": [
+      "load_one",
+      "proc_total"
     ]
   }
 ```
 
-The `loadavg` collector reads data from `/proc/loadavg` and outputs a handful **node** metrics. If a metric is not required, it can be excluded from forwarding it to the sink.
+The `loadavg` collector reads data from `/proc/loadavg` and outputs a handful **node** metrics.
+
+Both filtering mechanisms are supported:
+- `exclude_metrics`: Excludes the specified metrics.
+- `only_metrics`: If provided, only the listed metrics are collected. This takes precedence over `exclude_metrics`.
 
 Metrics:
-* `load_one`
-* `load_five`
-* `load_fifteen`
-* `proc_run`
-* `proc_total`
+- `load_one`
+- `load_five`
+- `load_fifteen`
+- `proc_run`
+- `proc_total`

--- a/collectors/lustreMetric.md
+++ b/collectors/lustreMetric.md
@@ -1,46 +1,65 @@
-
 ## `lustrestat` collector
 
 ```json
   "lustrestat": {
     "lctl_command": "/path/to/lctl",
     "exclude_metrics": [
-      "setattr",
-      "getattr"
+      "lustre_setattr",
+      "lustre_getattr"
     ],
-    "send_abs_values" : true,
-    "send_derived_values" : true,
+    "only_metrics": [
+      "lustre_read_bytes",
+      "lustre_read_bytes_diff",
+      "lustre_read_bw",
+      "lustre_open",
+      "lustre_open_diff"
+    ],
+    "send_abs_values": true,
     "send_diff_values": true,
+    "send_derived_values": true,
     "use_sudo": false
   }
 ```
 
 The `lustrestat` collector uses the `lctl` application with the `get_param` option to get all `llite` metrics (Lustre client). The `llite` metrics are only available for root users. If password-less sudo is configured, you can enable `sudo` in the configuration.
 
-Metrics:
-* `lustre_read_bytes` (unit `bytes`)
-* `lustre_read_requests` (unit `requests`)
-* `lustre_write_bytes` (unit `bytes`)
-* `lustre_write_requests` (unit `requests`)
-* `lustre_open`
-* `lustre_close`
-* `lustre_getattr`
-* `lustre_setattr`
-* `lustre_statfs`
-* `lustre_inode_permission`
-* `lustre_read_bw` (if `send_derived_values == true`, unit `bytes/sec`)
-* `lustre_write_bw` (if `send_derived_values == true`, unit `bytes/sec`)
-* `lustre_read_requests_rate` (if `send_derived_values == true`, unit `requests/sec`)
-* `lustre_write_requests_rate` (if `send_derived_values == true`, unit `requests/sec`)
-* `lustre_read_bytes_diff` (if `send_diff_values == true`, unit `bytes`)
-* `lustre_read_requests_diff` (if `send_diff_values == true`, unit `requests`)
-* `lustre_write_bytes_diff` (if `send_diff_values == true`, unit `bytes`)
-* `lustre_write_requests_diff` (if `send_diff_values == true`, unit `requests`)
-* `lustre_open_diff` (if `send_diff_values == true`)
-* `lustre_close_diff` (if `send_diff_values == true`)
-* `lustre_getattr_diff` (if `send_diff_values == true`)
-* `lustre_setattr_diff` (if `send_diff_values == true`)
-* `lustre_statfs_diff` (if `send_diff_values == true`)
-* `lustre_inode_permission_diff` (if `send_diff_values == true`)
+At least one of the settings for absolute, diff, and derived values must be set to true.
 
-This collector adds an `device` tag.
+Both filtering mechanisms are supported:
+- `exclude_metrics`: Excludes the specified metrics.
+- `only_metrics`: If provided, only the listed metrics are collected. This takes precedence over `exclude_metrics`.
+
+
+Metrics are categorized as follows:
+
+**Absolute Metrics:**
+- `lustre_read_bytes` (unit: `bytes`)
+- `lustre_read_requests` (unit: `requests`)
+- `lustre_write_bytes` (unit: `bytes`)
+- `lustre_write_requests` (unit: `requests`)
+- `lustre_open`
+- `lustre_close`
+- `lustre_getattr`
+- `lustre_setattr`
+- `lustre_statfs`
+- `lustre_inode_permission`
+
+**Diff Metrics:**
+- `lustre_read_bytes_diff` (unit: `bytes`)
+- `lustre_read_requests_diff` (unit: `requests`)
+- `lustre_write_bytes_diff` (unit: `bytes`)
+- `lustre_write_requests_diff` (unit: `requests`)
+- `lustre_open_diff`
+- `lustre_close_diff`
+- `lustre_getattr_diff`
+- `lustre_setattr_diff`
+- `lustre_statfs_diff`
+- `lustre_inode_permission_diff`
+
+**Derived Metrics:**
+- `lustre_read_bw` (unit: `bytes/sec`)
+- `lustre_write_bw` (unit: `bytes/sec`)
+- `lustre_read_requests_rate` (unit: `requests/sec`)
+- `lustre_write_requests_rate` (unit: `requests/sec`)
+
+This collector adds a `device` tag.

--- a/collectors/memstatMetric.md
+++ b/collectors/memstatMetric.md
@@ -1,9 +1,14 @@
-
 ## `memstat` collector
 
 ```json
   "memstat": {
     "exclude_metrics": [
+      "mem_buffera"
+    ],
+    "only_metrics": [
+      "mem_total",
+      "mem_free",
+      "mem_cached",
       "mem_used"
     ]
   }
@@ -11,17 +16,20 @@
 
 The `memstat` collector reads data from `/proc/meminfo` and outputs a handful **node** metrics. If a metric is not required, it can be excluded from forwarding it to the sink.
 
+Both filtering mechanisms are supported:
+- `exclude_metrics`: Excludes the specified metrics.
+- `only_metrics`: If provided, only the listed metrics are collected. This takes precedence over `exclude_metrics`.
+
 
 Metrics:
-* `mem_total`
-* `mem_sreclaimable`
-* `mem_slab`
-* `mem_free`
-* `mem_buffers`
-* `mem_cached`
-* `mem_available`
-* `mem_shared`
-* `swap_total`
-* `swap_free`
-* `mem_used` = `mem_total` - (`mem_free` + `mem_buffers` + `mem_cached`)
-
+- `mem_total`
+- `mem_sreclaimable`
+- `mem_slab`
+- `mem_free`
+- `mem_buffers`
+- `mem_cached`
+- `mem_available`
+- `mem_shared`
+- `swap_total`
+- `swap_free`
+- `mem_used` = `mem_total` - (`mem_free` + `mem_buffers` + `mem_cached`)

--- a/collectors/metricCollector.go
+++ b/collectors/metricCollector.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	lp "github.com/ClusterCockpit/cc-energy-manager/pkg/cc-message"
+	lp "github.com/ClusterCockpit/cc-lib/pkg/ccMessage"
 )
 
 type MetricCollector interface {
@@ -14,7 +14,7 @@ type MetricCollector interface {
 	Initialized() bool                 // Is metric collector initialized?
 	Parallel() bool
 	Read(duration time.Duration, output chan lp.CCMessage) // Read metrics from metric collector
-	Close()                                               // Close / finish metric collector
+	Close()                                                // Close / finish metric collector
 }
 
 type metricCollector struct {

--- a/collectors/netstatMetric.md
+++ b/collectors/netstatMetric.md
@@ -1,27 +1,42 @@
-
 ## `netstat` collector
 
 ```json
   "netstat": {
     "include_devices": [
-      "eth0"
+      "eth0",
+      "eno1"
     ],
-    "send_abs_values" : true,
-    "send_derived_values" : true
+    "send_abs_values": true,
+    "send_derived_values": true,
+    "interface_aliases": {
+      "eno1": ["eno1np0", "eno1_alt"],
+      "eth0": ["eth0_alias"]
+    },
+    "exclude_metrics": [
+      "net_pkts_in"
+    ],
+    "only_metrics": [
+      "net_bytes_in_bw"
+    ]
   }
 ```
 
-The `netstat` collector reads data from `/proc/net/dev` and outputs a handful **node** metrics. With the `include_devices` list you can specify which network devices should be measured. **Note**: Most other collectors use an _exclude_ list instead of an include list.
+The `netstat` collector reads data from `/proc/net/dev` and outputs a handful **node** metrics. With the `include_devices` list you can specify which network interfaces should be measured. Optionally, you can define an `interface_aliases` mapping. For each canonical device (as listed in include_devices), you may provide an array of aliases that may be reported by the system. When an alias is detected, it is mapped to the canonical name, while the output tag `stype-id` always shows the actual system-reported name.
 
-Metrics:
-* `net_bytes_in` (`unit=bytes`)
-* `net_bytes_out` (`unit=bytes`)
-* `net_pkts_in` (`unit=packets`)
-* `net_pkts_out` (`unit=packets`)
-* `net_bytes_in_bw` (`unit=bytes/sec` if `send_derived_values == true`)
-* `net_bytes_out_bw` (`unit=bytes/sec` if `send_derived_values == true`)
-* `net_pkts_in_bw` (`unit=packets/sec` if `send_derived_values == true`)
-* `net_pkts_out_bw` (`unit=packets/sec` if `send_derived_values == true`)
+Both filtering mechanisms are supported:
+- `exclude_metrics`: Excludes the specified metrics.
+- `only_metrics`: If provided, only the listed metrics are collected. This takes precedence over `exclude_metrics`.
+
+**Absolute Metrics:**
+- `net_bytes_in` (unit: `bytes`)
+- `net_bytes_out` (unit: `bytes`)
+- `net_pkts_in` (unit: `packets`)
+- `net_pkts_out` (unit: `packets`)
+
+**Derived Metrics:**
+- `net_bytes_in_bw` (unit: `bytes/sec`)
+- `net_bytes_out_bw` (unit: `bytes/sec`)
+- `net_pkts_in_bw` (unit: `packets/sec`)
+- `net_pkts_out_bw` (unit: `packets/sec`)
 
 The device name is added as tag `stype=network,stype-id=<device>`.
-

--- a/collectors/nfs3Metric.md
+++ b/collectors/nfs3Metric.md
@@ -1,39 +1,52 @@
-
 ## `nfs3stat` collector
 
 ```json
   "nfs3stat": {
-    "nfsstat" : "/path/to/nfsstat",
+    "nfsstat": "/path/to/nfsstat",
     "exclude_metrics": [
-      "nfs3_total"
-    ]
+      "total"
+    ],
+    "only_metrics": [
+      "read_diff"
+    ],
+    "send_abs_values": true,
+    "send_diff_values": true,
+    "send_derived_values": true
   }
 ```
 
-The `nfs3stat` collector reads data from `nfsstat` command and outputs a handful **node** metrics. If a metric is not required, it can be excluded from forwarding it to the sink. There is currently no possibility to get the metrics per mount point.
+The `nfs3stat` collector reads data from `nfsstat` command and outputs a handful **node** metrics.
 
+Both filtering mechanisms are supported:
+- `exclude_metrics`: Excludes the specified metrics. Uses base metric names without the nfs3_ prefix.
+- `only_metrics`: If provided, only the listed metrics are collected. This takes precedence over `exclude_metrics`.
 
-Metrics:
-* `nfs3_total` 
-* `nfs3_null` 
-* `nfs3_getattr` 
-* `nfs3_setattr` 
-* `nfs3_lookup` 
-* `nfs3_access` 
-* `nfs3_readlink` 
-* `nfs3_read` 
-* `nfs3_write` 
-* `nfs3_create` 
-* `nfs3_mkdir` 
-* `nfs3_symlink` 
-* `nfs3_remove` 
-* `nfs3_rmdir` 
-* `nfs3_rename` 
-* `nfs3_link` 
-* `nfs3_readdir` 
-* `nfs3_readdirplus` 
-* `nfs3_fsstat` 
-* `nfs3_fsinfo` 
-* `nfs3_pathconf` 
-* `nfs3_commit` 
+**Absolute Metrics:**
+- `nfs3_total`
+- `nfs3_null`
+- `nfs3_getattr`
+- `nfs3_setattr`
+- `nfs3_lookup`
+- `nfs3_access`
+- `nfs3_readlink`
+- `nfs3_read`
+- `nfs3_write`
+- `nfs3_create`
+- `nfs3_mkdir`
+- `nfs3_symlink`
+- `nfs3_remove`
+- `nfs3_rmdir`
+- `nfs3_rename`
+- `nfs3_link`
+- `nfs3_readdir`
+- `nfs3_readdirplus`
+- `nfs3_fsstat`
+- `nfs3_fsinfo`
+- `nfs3_pathconf`
+- `nfs3_commit`
 
+**Diff Metrics:**
+For each metric, if `send_diff_values` is enabled, the collector computes the difference (current value minus previous value) and sends it with the suffix `_diff`.
+
+**Derived Metrics:**
+For each metric, if `send_derived_values` is enabled, the collector computes the rate (difference divided by the time interval) and sends it with the suffix `_rate`.

--- a/collectors/nfs4Metric.md
+++ b/collectors/nfs4Metric.md
@@ -1,62 +1,76 @@
-
 ## `nfs4stat` collector
 
 ```json
   "nfs4stat": {
-    "nfsstat" : "/path/to/nfsstat",
+    "nfsstat": "/path/to/nfsstat",
     "exclude_metrics": [
-      "nfs4_total"
-    ]
+      "total"
+    ],
+    "only_metrics": [
+      "read"
+    ],
+    "send_abs_values": true,
+    "send_diff_values": true,
+    "send_derived_values": true
   }
 ```
 
-The `nfs4stat` collector reads data from `nfsstat` command and outputs a handful **node** metrics. If a metric is not required, it can be excluded from forwarding it to the sink. There is currently no possibility to get the metrics per mount point.
+The `nfs4stat` collector reads data from `nfsstat` command and outputs a handful **node** metrics. 
+
+Both filtering mechanisms are supported:
+- `exclude_metrics`: Excludes the specified metrics. Uses base metric names without the nfs4_ prefix.
+- `only_metrics`: If provided, only the listed metrics are collected. This takes precedence over `exclude_metrics`.
 
 
-Metrics:
-* `nfs4_total` 
-* `nfs4_null` 
-* `nfs4_read` 
-* `nfs4_write` 
-* `nfs4_commit` 
-* `nfs4_open` 
-* `nfs4_open_conf` 
-* `nfs4_open_noat` 
-* `nfs4_open_dgrd` 
-* `nfs4_close` 
-* `nfs4_setattr` 
-* `nfs4_fsinfo` 
-* `nfs4_renew` 
-* `nfs4_setclntid` 
-* `nfs4_confirm` 
-* `nfs4_lock` 
-* `nfs4_lockt` 
-* `nfs4_locku` 
-* `nfs4_access` 
-* `nfs4_getattr` 
-* `nfs4_lookup` 
-* `nfs4_lookup_root` 
-* `nfs4_remove` 
-* `nfs4_rename` 
-* `nfs4_link` 
-* `nfs4_symlink` 
-* `nfs4_create` 
-* `nfs4_pathconf` 
-* `nfs4_statfs` 
-* `nfs4_readlink` 
-* `nfs4_readdir` 
-* `nfs4_server_caps` 
-* `nfs4_delegreturn` 
-* `nfs4_getacl` 
-* `nfs4_setacl` 
-* `nfs4_rel_lkowner` 
-* `nfs4_exchange_id` 
-* `nfs4_create_session` 
-* `nfs4_destroy_session` 
-* `nfs4_sequence` 
-* `nfs4_get_lease_time` 
-* `nfs4_reclaim_comp` 
-* `nfs4_secinfo_no` 
-* `nfs4_bind_conn_to_ses` 
+**Absolute Metrics:**
+- `nfs4_total`
+- `nfs4_null`
+- `nfs4_read`
+- `nfs4_write`
+- `nfs4_commit`
+- `nfs4_open`
+- `nfs4_open_conf`
+- `nfs4_open_noat`
+- `nfs4_open_dgrd`
+- `nfs4_close`
+- `nfs4_setattr`
+- `nfs4_fsinfo`
+- `nfs4_renew`
+- `nfs4_setclntid`
+- `nfs4_confirm`
+- `nfs4_lock`
+- `nfs4_lockt`
+- `nfs4_locku`
+- `nfs4_access`
+- `nfs4_getattr`
+- `nfs4_lookup`
+- `nfs4_lookup_root`
+- `nfs4_remove`
+- `nfs4_rename`
+- `nfs4_link`
+- `nfs4_symlink`
+- `nfs4_create`
+- `nfs4_pathconf`
+- `nfs4_statfs`
+- `nfs4_readlink`
+- `nfs4_readdir`
+- `nfs4_server_caps`
+- `nfs4_delegreturn`
+- `nfs4_getacl`
+- `nfs4_setacl`
+- `nfs4_rel_lkowner`
+- `nfs4_exchange_id`
+- `nfs4_create_session`
+- `nfs4_destroy_session`
+- `nfs4_sequence`
+- `nfs4_get_lease_time`
+- `nfs4_reclaim_comp`
+- `nfs4_secinfo_no`
+- `nfs4_bind_conn_to_ses`
+- `nfs4_seek`
 
+**Diff Metrics:**
+For each metric, if `send_diff_values` is enabled, the collector computes the difference and sends it with the suffix `_diff`.
 
+**Derived Metrics:**
+For each metric, if `send_derived_values` is enabled, the collector computes the rate (difference divided by the time interval) and sends it with the suffix `_rate`.

--- a/collectors/nfsMetric.go
+++ b/collectors/nfsMetric.go
@@ -3,15 +3,12 @@ package collectors
 import (
 	"encoding/json"
 	"fmt"
-	"log"
-
-	//	"os"
 	"os/exec"
 	"strconv"
 	"strings"
 	"time"
 
-	lp "github.com/ClusterCockpit/cc-energy-manager/pkg/cc-message"
+	lp "github.com/ClusterCockpit/cc-lib/ccMessage"
 )
 
 // First part contains the code for the general NfsCollector.
@@ -29,8 +26,12 @@ type nfsCollector struct {
 	tags    map[string]string
 	version string
 	config  struct {
-		Nfsstats       string   `json:"nfsstat"`
-		ExcludeMetrics []string `json:"exclude_metrics,omitempty"`
+		Nfsstats           string   `json:"nfsstat"`
+		ExcludeMetrics     []string `json:"exclude_metrics,omitempty"`
+		OnlyMetrics        []string `json:"only_metrics,omitempty"`
+		SendAbsoluteValues bool     `json:"send_abs_values,omitempty"`
+		SendDiffValues     bool     `json:"send_diff_values,omitempty"`
+		SendDerivedValues  bool     `json:"send_derived_values,omitempty"`
 	}
 	data map[string]NfsCollectorData
 }
@@ -46,14 +47,12 @@ func (m *nfsCollector) initStats() error {
 				continue
 			}
 			if lf[1] == m.version {
+				// Use the base metric name (without prefix) for filtering.
 				name := strings.Trim(lf[3], ":")
 				if _, exist := m.data[name]; !exist {
 					value, err := strconv.ParseInt(lf[4], 0, 64)
 					if err == nil {
-						x := m.data[name]
-						x.current = value
-						x.last = value
-						m.data[name] = x
+						m.data[name] = NfsCollectorData{current: value, last: value}
 					}
 				}
 			}
@@ -89,24 +88,42 @@ func (m *nfsCollector) updateStats() error {
 	return err
 }
 
+// shouldOutput returns true if a metric (base name + variant) should be forwarded.
+// The variant is "" for absolute, "_diff" for diff, and "_rate" for derived.
+// If only_metrics is set, only the metric names that exactly match (base+variant) are forwarded.
+func (m *nfsCollector) shouldOutput(baseName, variant string) bool {
+	finalName := baseName + variant
+	if len(m.config.OnlyMetrics) > 0 {
+		for _, n := range m.config.OnlyMetrics {
+			if n == finalName {
+				return true
+			}
+		}
+		return false
+	}
+	for _, n := range m.config.ExcludeMetrics {
+		if n == finalName {
+			return false
+		}
+	}
+	return true
+}
+
 func (m *nfsCollector) MainInit(config json.RawMessage) error {
-	m.config.Nfsstats = string(NFSSTAT_EXEC)
-	// Read JSON configuration
+	m.config.Nfsstats = NFSSTAT_EXEC
 	if len(config) > 0 {
 		err := json.Unmarshal(config, &m.config)
 		if err != nil {
-			log.Print(err.Error())
 			return err
 		}
 	}
-	m.meta = map[string]string{
-		"source": m.name,
-		"group":  "NFS",
+	// For backwards compatibility, send_abs_values defaults to true.
+	if !m.config.SendAbsoluteValues {
+		m.config.SendAbsoluteValues = true
 	}
-	m.tags = map[string]string{
-		"type": "node",
-	}
-	// Check if nfsstat is in executable search path
+	// Diff and derived default to false if not specified.
+	m.meta = map[string]string{"source": m.name, "group": "NFS"}
+	m.tags = map[string]string{"type": "node"}
 	_, err := exec.LookPath(m.config.Nfsstats)
 	if err != nil {
 		return fmt.Errorf("NfsCollector.Init(): Failed to find nfsstat binary '%s': %v", m.config.Nfsstats, err)
@@ -123,7 +140,6 @@ func (m *nfsCollector) Read(interval time.Duration, output chan lp.CCMessage) {
 		return
 	}
 	timestamp := time.Now()
-
 	m.updateStats()
 	prefix := ""
 	switch m.version {
@@ -134,16 +150,32 @@ func (m *nfsCollector) Read(interval time.Duration, output chan lp.CCMessage) {
 	default:
 		prefix = "nfs"
 	}
-
 	for name, data := range m.data {
-		if _, skip := stringArrayContains(m.config.ExcludeMetrics, name); skip {
-			continue
+		// For each metric, apply filtering based on the final output name.
+		// Absolute metric: final name = prefix + "_" + name
+		if m.config.SendAbsoluteValues && m.shouldOutput(name, "") {
+			absMsg, err := lp.NewMessage(fmt.Sprintf("%s_%s", prefix, name), m.tags, m.meta, map[string]interface{}{"value": data.current}, timestamp)
+			if err == nil {
+				absMsg.AddMeta("version", m.version)
+				output <- absMsg
+			}
 		}
-		value := data.current - data.last
-		y, err := lp.NewMessage(fmt.Sprintf("%s_%s", prefix, name), m.tags, m.meta, map[string]interface{}{"value": value}, timestamp)
-		if err == nil {
-			y.AddMeta("version", m.version)
-			output <- y
+		if m.config.SendDiffValues && m.shouldOutput(name, "_diff") {
+			diff := data.current - data.last
+			diffMsg, err := lp.NewMessage(fmt.Sprintf("%s_%s_diff", prefix, name), m.tags, m.meta, map[string]interface{}{"value": diff}, timestamp)
+			if err == nil {
+				diffMsg.AddMeta("version", m.version)
+				output <- diffMsg
+			}
+		}
+		if m.config.SendDerivedValues && m.shouldOutput(name, "_rate") {
+			diff := data.current - data.last
+			rate := float64(diff) / interval.Seconds()
+			derivedMsg, err := lp.NewMessage(fmt.Sprintf("%s_%s_rate", prefix, name), m.tags, m.meta, map[string]interface{}{"value": rate}, timestamp)
+			if err == nil {
+				derivedMsg.AddMeta("version", m.version)
+				output <- derivedMsg
+			}
 		}
 	}
 }
@@ -162,14 +194,14 @@ type Nfs4Collector struct {
 
 func (m *Nfs3Collector) Init(config json.RawMessage) error {
 	m.name = "Nfs3Collector"
-	m.version = `v3`
+	m.version = "v3"
 	m.setup()
 	return m.MainInit(config)
 }
 
 func (m *Nfs4Collector) Init(config json.RawMessage) error {
 	m.name = "Nfs4Collector"
-	m.version = `v4`
+	m.version = "v4"
 	m.setup()
 	return m.MainInit(config)
 }

--- a/collectors/nfsiostatMetric.go
+++ b/collectors/nfsiostatMetric.go
@@ -9,31 +9,36 @@ import (
 	"strings"
 	"time"
 
+	lp "github.com/ClusterCockpit/cc-lib/ccMessage"
 	cclog "github.com/ClusterCockpit/cc-metric-collector/pkg/ccLogger"
-	lp "github.com/ClusterCockpit/cc-energy-manager/pkg/cc-message"
 )
 
-// These are the fields we read from the JSON configuration
+// NfsIOStatCollectorConfig holds configuration options for the nfsiostat collector.
 type NfsIOStatCollectorConfig struct {
 	ExcludeMetrics          []string `json:"exclude_metrics,omitempty"`
+	OnlyMetrics             []string `json:"only_metrics,omitempty"`
 	ExcludeFilesystem       []string `json:"exclude_filesystem,omitempty"`
 	UseServerAddressAsSType bool     `json:"use_server_as_stype,omitempty"`
+	SendAbsoluteValues      bool     `json:"send_abs_values"`
+	SendDerivedValues       bool     `json:"send_derived_values"`
 }
 
-// This contains all variables we need during execution and the variables
-// defined by metricCollector (name, init, ...)
+// NfsIOStatCollector reads NFS I/O statistics from /proc/self/mountstats.
 type NfsIOStatCollector struct {
 	metricCollector
-	config NfsIOStatCollectorConfig    // the configuration structure
-	meta   map[string]string           // default meta information
-	tags   map[string]string           // default tags
-	data   map[string]map[string]int64 // data storage for difference calculation
-	key    string                      // which device info should be used as subtype ID? 'server' or 'mntpoint', see NfsIOStatCollectorConfig.UseServerAddressAsSType
+	config        NfsIOStatCollectorConfig
+	meta          map[string]string
+	tags          map[string]string
+	data          map[string]map[string]int64 // previous values per filesystem
+	key           string                      // "server" or "mntpoint"
+	lastTimestamp time.Time
 }
 
+// Regular expressions to parse mount info and byte statistics.
 var deviceRegex = regexp.MustCompile(`device (?P<server>[^ ]+) mounted on (?P<mntpoint>[^ ]+) with fstype nfs(?P<version>\d*) statvers=[\d\.]+`)
 var bytesRegex = regexp.MustCompile(`\s+bytes:\s+(?P<nread>[^ ]+) (?P<nwrite>[^ ]+) (?P<dread>[^ ]+) (?P<dwrite>[^ ]+) (?P<nfsread>[^ ]+) (?P<nfswrite>[^ ]+) (?P<pageread>[^ ]+) (?P<pagewrite>[^ ]+)`)
 
+// resolve_regex_fields extracts named regex groups from a string.
 func resolve_regex_fields(s string, regex *regexp.Regexp) map[string]string {
 	fields := make(map[string]string)
 	groups := regex.SubexpNames()
@@ -47,6 +52,52 @@ func resolve_regex_fields(s string, regex *regexp.Regexp) map[string]string {
 	return fields
 }
 
+// shouldOutput returns true if a base metric (without prefix) is allowed.
+func (m *NfsIOStatCollector) shouldOutput(metricName string) bool {
+	if len(m.config.OnlyMetrics) > 0 {
+		for _, n := range m.config.OnlyMetrics {
+			if n == metricName {
+				return true
+			}
+		}
+		return false
+	}
+	for _, n := range m.config.ExcludeMetrics {
+		if n == metricName {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *NfsIOStatCollector) Init(config json.RawMessage) error {
+	var err error
+	m.name = "NfsIOStatCollector"
+	m.setup()
+	m.parallel = true
+	m.meta = map[string]string{"source": m.name, "group": "NFS", "unit": "bytes"}
+	m.tags = map[string]string{"type": "node"}
+	// Default: use_server_as_stype is false.
+	m.config.UseServerAddressAsSType = false
+	// Defaults for absolute and derived values.
+	m.config.SendAbsoluteValues = false
+	m.config.SendDerivedValues = true
+	if len(config) > 0 {
+		if err = json.Unmarshal(config, &m.config); err != nil {
+			cclog.ComponentError(m.name, "Error reading config:", err.Error())
+			return err
+		}
+	}
+	m.key = "mntpoint"
+	if m.config.UseServerAddressAsSType {
+		m.key = "server"
+	}
+	m.data = m.readNfsiostats()
+	m.lastTimestamp = time.Now()
+	m.init = true
+	return nil
+}
+
 func (m *NfsIOStatCollector) readNfsiostats() map[string]map[string]int64 {
 	data := make(map[string]map[string]int64)
 	filename := "/proc/self/mountstats"
@@ -58,7 +109,7 @@ func (m *NfsIOStatCollector) readNfsiostats() map[string]map[string]int64 {
 	lines := strings.Split(string(stats), "\n")
 	var current map[string]string = nil
 	for _, l := range lines {
-		// Is this a device line with mount point, remote target and NFS version?
+		// Check for a device line.
 		dev := resolve_regex_fields(l, deviceRegex)
 		if len(dev) > 0 {
 			if _, ok := stringArrayContains(m.config.ExcludeFilesystem, dev[m.key]); !ok {
@@ -66,22 +117,35 @@ func (m *NfsIOStatCollector) readNfsiostats() map[string]map[string]int64 {
 				if len(current["version"]) == 0 {
 					current["version"] = "3"
 				}
+			} else {
+				current = nil
 			}
 		}
-
-		if len(current) > 0 {
-			// Byte line parsing (if found the device for it)
+		if current != nil {
+			// Parse byte statistics line.
 			bytes := resolve_regex_fields(l, bytesRegex)
 			if len(bytes) > 0 {
 				data[current[m.key]] = make(map[string]int64)
 				for name, sval := range bytes {
-					if _, ok := stringArrayContains(m.config.ExcludeMetrics, name); !ok {
-						val, err := strconv.ParseInt(sval, 10, 64)
-						if err == nil {
-							data[current[m.key]][name] = val
+					if _, ok := stringArrayContains(m.config.ExcludeMetrics, name); ok {
+						continue
+					}
+					if len(m.config.OnlyMetrics) > 0 {
+						found := false
+						for _, metric := range m.config.OnlyMetrics {
+							if metric == name {
+								found = true
+								break
+							}
+						}
+						if !found {
+							continue
 						}
 					}
-
+					val, err := strconv.ParseInt(sval, 10, 64)
+					if err == nil {
+						data[current[m.key]][name] = val
+					}
 				}
 				current = nil
 			}
@@ -90,65 +154,56 @@ func (m *NfsIOStatCollector) readNfsiostats() map[string]map[string]int64 {
 	return data
 }
 
-func (m *NfsIOStatCollector) Init(config json.RawMessage) error {
-	var err error = nil
-	m.name = "NfsIOStatCollector"
-	m.setup()
-	m.parallel = true
-	m.meta = map[string]string{"source": m.name, "group": "NFS", "unit": "bytes"}
-	m.tags = map[string]string{"type": "node"}
-	m.config.UseServerAddressAsSType = false
-	if len(config) > 0 {
-		err = json.Unmarshal(config, &m.config)
-		if err != nil {
-			cclog.ComponentError(m.name, "Error reading config:", err.Error())
-			return err
-		}
-	}
-	m.key = "mntpoint"
-	if m.config.UseServerAddressAsSType {
-		m.key = "server"
-	}
-	m.data = m.readNfsiostats()
-	m.init = true
-	return err
-}
-
 func (m *NfsIOStatCollector) Read(interval time.Duration, output chan lp.CCMessage) {
-	timestamp := time.Now()
+	now := time.Now()
+	timeDiff := now.Sub(m.lastTimestamp).Seconds()
+	m.lastTimestamp = now
 
-	// Get the current values for all mountpoints
 	newdata := m.readNfsiostats()
 
 	for mntpoint, values := range newdata {
-		// Was the mount point already present in the last iteration
-		if old, ok := m.data[mntpoint]; ok {
-			// Calculate the difference of old and new values
-			for i := range values {
-				x := values[i] - old[i]
-				y, err := lp.NewMessage(fmt.Sprintf("nfsio_%s", i), m.tags, m.meta, map[string]interface{}{"value": x}, timestamp)
+		if _, ok := stringArrayContains(m.config.ExcludeFilesystem, mntpoint); ok {
+			continue
+		}
+		for name, newVal := range values {
+			baseName := name // Base metric name.
+			if m.config.SendAbsoluteValues && m.shouldOutput(baseName) {
+				msg, err := lp.NewMessage(fmt.Sprintf("nfsio_%s", baseName), m.tags, m.meta, map[string]interface{}{"value": newVal}, now)
 				if err == nil {
-					if strings.HasPrefix(i, "page") {
-						y.AddMeta("unit", "4K_Pages")
-					}
-					y.AddTag("stype", "filesystem")
-					y.AddTag("stype-id", mntpoint)
-					// Send it to output channel
-					output <- y
+					msg.AddTag("stype", "filesystem")
+					msg.AddTag("stype-id", mntpoint)
+					output <- msg
 				}
-				// Update old to the new value for the next iteration
-				old[i] = values[i]
 			}
-		} else {
-			// First time we see this mount point, store all values
-			m.data[mntpoint] = values
+			if m.config.SendDerivedValues {
+				if old, ok := m.data[mntpoint][name]; ok {
+					rate := float64(newVal-old) / timeDiff
+					if m.shouldOutput(baseName) {
+						msg, err := lp.NewMessage(fmt.Sprintf("nfsio_%s_bw", baseName), m.tags, m.meta, map[string]interface{}{"value": rate}, now)
+						if err == nil {
+							if strings.HasPrefix(name, "page") {
+								msg.AddMeta("unit", "4K_pages/s")
+							} else {
+								msg.AddMeta("unit", "bytes/sec")
+							}
+							msg.AddTag("stype", "filesystem")
+							msg.AddTag("stype-id", mntpoint)
+							output <- msg
+						}
+					}
+				}
+			}
+			if m.data[mntpoint] == nil {
+				m.data[mntpoint] = make(map[string]int64)
+			}
+			m.data[mntpoint][name] = newVal
 		}
 	}
-	// Reset entries that do not exist anymore
+	// Remove mountpoints that no longer exist.
 	for mntpoint := range m.data {
 		found := false
-		for new := range newdata {
-			if new == mntpoint {
+		for newMnt := range newdata {
+			if newMnt == mntpoint {
 				found = true
 				break
 			}
@@ -157,10 +212,8 @@ func (m *NfsIOStatCollector) Read(interval time.Duration, output chan lp.CCMessa
 			m.data[mntpoint] = nil
 		}
 	}
-
 }
 
 func (m *NfsIOStatCollector) Close() {
-	// Unset flag
 	m.init = false
 }

--- a/collectors/nfsiostatMetric.md
+++ b/collectors/nfsiostatMetric.md
@@ -3,25 +3,42 @@
 ```json
   "nfsiostat": {
     "exclude_metrics": [
-      "nfsio_oread"
+      "oread", "pageread"
     ],
-    "exclude_filesystems" : [
-        "/mnt",
+    "only_metrics": [
+      "nread", "nwrite", "nfsread", "nfswrite"
     ],
-    "use_server_as_stype": false
+    "exclude_filesystem": [
+      "/mnt"
+    ],
+    "use_server_as_stype": false,
+    "send_abs_values": false,
+    "send_derived_values": true
   }
 ```
 
-The `nfsiostat` collector reads data from `/proc/self/mountstats` and outputs a handful **node** metrics for each NFS filesystem. If a metric or filesystem is not required, it can be excluded from forwarding it to the sink.
+The `nfsiostat` collector reads data from `/proc/self/mountstats` and outputs a handful **node**s metrics for each NFS filesystem.
+Metrics are output with the prefix `nfsio_` and the base metric name (e.g. `nread`, `nwrite`, etc.). Filtering applies to the base metric name (without the `nfsio_` prefix).
 
-Metrics:
-* `nfsio_nread`: Bytes transferred by normal `read()` calls
-* `nfsio_nwrite`: Bytes transferred by normal `write()` calls
-* `nfsio_oread`: Bytes transferred by `read()` calls with `O_DIRECT`
-* `nfsio_owrite`: Bytes transferred by `write()` calls with `O_DIRECT`
-* `nfsio_pageread`: Pages transferred by `read()` calls
-* `nfsio_pagewrite`: Pages transferred by `write()` calls
-* `nfsio_nfsread`: Bytes transferred for reading from the server
-* `nfsio_nfswrite`: Pages transferred by writing to the server
+Both filtering mechanisms are supported:
+- `exclude_metrics`: Excludes the specified metrics.
+- `only_metrics`: If provided, only the listed metrics are collected. This takes precedence over `exclude_metrics`.
+
+Metrics are categorized as follows:
+
+**Absolute Metrics:**
+- `nfsio_nread`: Bytes transferred by normal read() calls
+- `nfsio_nwrite`: Bytes transferred by normal write() calls
+- `nfsio_oread`: Bytes transferred by read() calls with O_DIRECT
+- `nfsio_owrite`: Bytes transferred by write() calls with O_DIRECT
+- `nfsio_pageread`: Pages transferred by read() calls
+- `nfsio_pagewrite`: Pages transferred by write() calls
+- `nfsio_nfsread`: Bytes transferred for reading from the server
+- `nfsio_nfswrite`: Bytes transferred for writing to the server
+
+**Derived Metrics:**
+For each absolute metric, if `send_derived_values` is enabled, an additional metric is sent with the `_bw` suffix, representing the rate:
+- For byte metrics: `unit=bytes/sec`
+- For page metrics: `unit=4K_pages/s`
 
 The `nfsiostat` collector adds the mountpoint to the tags as `stype=filesystem,stype-id=<mountpoint>`. If the server address should be used instead of the mountpoint, use the `use_server_as_stype` config setting.

--- a/collectors/numastatsMetric.md
+++ b/collectors/numastatsMetric.md
@@ -1,17 +1,43 @@
-
 ## `numastat` collector
 
 ```json
-  "numastats": {}
+  "numastats": {
+    "send_abs_values": true,
+    "send_diff_values": true,
+    "send_derived_values": true,
+    "exclude_metrics": [],
+    "only_metrics": []
+  }
 ```
 
 The `numastat` collector reads data from `/sys/devices/system/node/node*/numastat` and outputs a handful **memoryDomain** metrics. See: <https://www.kernel.org/doc/html/latest/admin-guide/numastat.html>
 
-Metrics:
+Both filtering mechanisms are supported:
+- `exclude_metrics`: Excludes the specified metrics.
+- `only_metrics`: If provided, only the listed metrics are collected. This takes precedence over `exclude_metrics`.
 
-* `numastats_numa_hit`: A process wanted to allocate memory from this node, and succeeded.
-* `numastats_numa_miss`: A process wanted to allocate memory from another node, but ended up with memory from this node.
-* `numastats_numa_foreign`: A process wanted to allocate on this node, but ended up with memory from another node.
-* `numastats_local_node`: A process ran on this node's CPU, and got memory from this node.
-* `numastats_other_node`: A process ran on a different node's CPU, and got memory from this node.
-* `numastats_interleave_hit`: Interleaving wanted to allocate from this node and succeeded.
+Metrics are categorized as follows:
+
+**Absolute Metrics:** (unit: `count`)
+- `numastats_numa_hit`: A process wanted to allocate memory from this node, and succeeded.
+- `numastats_numa_miss`: A process wanted to allocate memory from another node, but ended up with memory from this node.
+- `numastats_numa_foreign`: A process wanted to allocate on this node, but ended up with memory from another node.
+- `numastats_local_node`: A process ran on this node's CPU, and got memory from this node.
+- `numastats_other_node`: A process ran on a different node's CPU, and got memory from this node.
+- `numastats_interleave_hit`: Interleaving wanted to allocate from this node and succeeded.
+
+**Diff Metrics:** (unit: `count`)
+- `numastats_numa_hit_diff`
+- `numastats_numa_miss_diff`
+- `numastats_numa_foreign_diff`
+- `numastats_local_node_diff`
+- `numastats_other_node_diff`
+- `numastats_interleave_hit_diff`
+
+**Derived Metrics:** (unit: `counts/s`)
+- `numastats_numa_hit_rate`
+- `numastats_numa_miss_rate`
+- `numastats_numa_foreign_rate`
+- `numastats_local_node_rate`
+- `numastats_other_node_rate`
+- `numastats_interleave_hit_rate`

--- a/collectors/nvidiaMetric.md
+++ b/collectors/nvidiaMetric.md
@@ -1,15 +1,21 @@
-
 ## `nvidia` collector
 
-```json
+{
   "nvidia": {
     "exclude_devices": [
-      "0","1", "0000000:ff:01.0"
+      "0",
+      "1",
+      "00000000:FF:01.0"
     ],
     "exclude_metrics": [
       "nv_fb_mem_used",
       "nv_fan"
     ],
+    "only_metrics": [
+      "nv_nvlink_ecc_errors_sum",
+      "nv_nvlink_ecc_errors_sum_diff"
+    ],
+    "send_diff_values": true,
     "process_mig_devices": false,
     "use_pci_info_as_type_id": true,
     "add_pci_info_tag": false,
@@ -17,60 +23,110 @@
     "add_board_number_meta": false,
     "add_serial_meta": false,
     "use_uuid_for_mig_device": false,
-    "use_slice_for_mig_device": false
+    "use_slice_for_mig_device": false,
+    "use_memory_info_v2": false
   }
-```
+}
 
-The `nvidia` collector can be configured to leave out specific devices with the `exclude_devices` option. It takes IDs as supplied to the NVML with `nvmlDeviceGetHandleByIndex()` or the PCI address in NVML format (`%08X:%02X:%02X.0`). Metrics (listed below) that should not be sent to the MetricRouter can be excluded with the `exclude_metrics` option. Commonly only the physical GPUs are monitored. If MIG devices should be analyzed as well, set `process_mig_devices` (adds `stype=mig,stype-id=<mig_index>`). With the options `use_uuid_for_mig_device` and `use_slice_for_mig_device`, the `<mig_index>` can be replaced with the UUID (e.g. `MIG-6a9f7cc8-6d5b-5ce0-92de-750edc4d8849`) or the MIG slice name (e.g. `1g.5gb`).
+The `nvidia` collector gathers metrics from NVIDIA GPUs using the NVIDIA Management Library (NVML). It can be configured to exclude specific devices with the `exclude_devices` option, which accepts device indices (e.g., `"0"`, `"1"`) as used by `nvmlDeviceGetHandleByIndex()` or PCI addresses in NVML format (e.g., `"%08X:%02X:%02X.0"`).
 
-The metrics sent by the `nvidia` collector use `accelerator` as `type` tag. For the `type-id`, it uses the device handle index by default. With the `use_pci_info_as_type_id` option, the PCI ID is used instead. If both values should be added as tags, activate the `add_pci_info_tag` option. It uses the device handle index as `type-id` and adds the PCI ID as separate `pci_identifier` tag.
+Both filtering mechanisms are supported:
+- `exclude_metrics`: Excludes the specified metrics.
+- `only_metrics`: If provided, only the listed metrics are collected. This takes precedence over `exclude_metrics`.
 
-Optionally, it is possible to add the UUID, the board part number and the serial to the meta informations. They are not sent to the sinks (if not configured otherwise).
+### Differential Metrics
+- **`send_diff_values`**: When set to `true`, differential metrics (e.g., `nv_ecc_corrected_error_diff`, `nv_nvlink_ecc_errors_sum_diff`) are calculated and sent alongside absolute values. These represent the change since the last measurement.
 
+### MIG Devices
+By default, only physical GPUs are monitored. To include MIG (Multi-Instance GPU) devices, set `process_mig_devices` to `true`. This adds tags `stype=mig` and `stype-id=<mig_index>` to MIG-specific metrics. The `stype-id` can be customized:
+- **`use_uuid_for_mig_device`**: Uses the MIG UUID (e.g., `MIG-6a9f7cc8-6d5b-5ce0-92de-750edc4d8849`).
+- **`use_slice_for_mig_device`**: Uses the MIG slice name (e.g., `1g.5gb`).
 
-Metrics:
-* `nv_util`
-* `nv_mem_util`
-* `nv_fb_mem_total`
-* `nv_fb_mem_used`
-* `nv_bar1_mem_total`
-* `nv_bar1_mem_used`
-* `nv_temp`
-* `nv_fan`
-* `nv_ecc_mode`
-* `nv_perf_state`
-* `nv_power_usage`
-* `nv_graphics_clock`
-* `nv_sm_clock`
-* `nv_mem_clock`
-* `nv_video_clock`
-* `nv_max_graphics_clock`
-* `nv_max_sm_clock`
-* `nv_max_mem_clock`
-* `nv_max_video_clock`
-* `nv_ecc_uncorrected_error`
-* `nv_ecc_corrected_error`
-* `nv_power_max_limit`
-* `nv_encoder_util`
-* `nv_decoder_util`
-* `nv_remapped_rows_corrected`
-* `nv_remapped_rows_uncorrected`
-* `nv_remapped_rows_pending`
-* `nv_remapped_rows_failure`
-* `nv_compute_processes`
-* `nv_graphics_processes`
-* `nv_violation_power`
-* `nv_violation_thermal`
-* `nv_violation_sync_boost`
-* `nv_violation_board_limit`
-* `nv_violation_low_util`
-* `nv_violation_reliability`
-* `nv_violation_below_app_clock`
-* `nv_violation_below_base_clock`
-* `nv_nvlink_crc_flit_errors`
-* `nv_nvlink_crc_errors`
-* `nv_nvlink_ecc_errors`
-* `nv_nvlink_replay_errors`
-* `nv_nvlink_recovery_errors`
+### Tags and Metadata
+Metrics use `type=accelerator` as a tag. The `type-id` defaults to the device handle index. Additional options include:
+- **`use_pci_info_as_type_id`**: Uses the PCI ID (e.g., `00000000:FF:01.0`) as `type-id` instead of the index.
+- **`add_pci_info_tag`**: Adds the PCI ID as a separate `pci_identifier` tag, while keeping the index as `type-id`.
+- **`add_uuid_meta`**, **`add_board_number_meta`**, **`add_serial_meta`**: Add UUID, board part number, or serial number to the metadata (not sent to sinks unless configured otherwise).
 
-Some metrics add the additional sub type tag (`stype`) like the `nv_nvlink_*` metrics set `stype=nvlink,stype-id=<link_number>`. 
+### Memory Info
+- **`use_memory_info_v2`**: When `true`, uses `nvmlDeviceGetMemoryInfo_v2` for more detailed memory metrics (i.e.  `mem_reserved` not part of `mem_used`). Defaults to `false`, falling back to `nvmlDeviceGetMemoryInfo`.
+
+### Metrics
+The following metrics are available. All `nv_nvlink_*` metrics are always delivered as `_sum` (aggregated across all NVLinks). If multiple devices are present, they are also provided as per-device metrics with `stype=nvlink` and `stype-id=<link_number>`.
+
+#### Absolute Metrics
+- `nv_util` (unit: `%`)
+- `nv_mem_util` (unit: `%`)
+- `nv_fb_mem_total` (unit: `MByte`)
+- `nv_fb_mem_used` (unit: `MByte`)
+- `nv_fb_mem_reserved` (unit: `MByte`)
+- `nv_bar1_mem_total` (unit: `MByte`)
+- `nv_bar1_mem_used` (unit: `MByte`)
+- `nv_temp` (unit: `degC`)
+- `nv_fan` (unit: `%`)
+- `nv_ecc_mode`
+- `nv_perf_state`
+- `nv_power_usage` (unit: `watts`)
+- `nv_graphics_clock` (unit: `MHz`)
+- `nv_sm_clock` (unit: `MHz`)
+- `nv_mem_clock` (unit: `MHz`)
+- `nv_video_clock` (unit: `MHz`)
+- `nv_max_graphics_clock` (unit: `MHz`)
+- `nv_max_sm_clock` (unit: `MHz`)
+- `nv_max_mem_clock` (unit: `MHz`)
+- `nv_max_video_clock` (unit: `MHz`)
+- `nv_ecc_uncorrected_error`
+- `nv_ecc_corrected_error`
+- `nv_power_max_limit` (unit: `watts`)
+- `nv_encoder_util` (unit: `%`)
+- `nv_decoder_util` (unit: `%`)
+- `nv_remapped_rows_corrected`
+- `nv_remapped_rows_uncorrected`
+- `nv_remapped_rows_pending`
+- `nv_remapped_rows_failure`
+- `nv_compute_processes`
+- `nv_graphics_processes`
+- `nv_violation_power` (unit: `sec`)
+- `nv_violation_thermal` (unit: `sec`)
+- `nv_violation_sync_boost` (unit: `sec`)
+- `nv_violation_board_limit` (unit: `sec`)
+- `nv_violation_low_util` (unit: `sec`)
+- `nv_violation_reliability` (unit: `sec`)
+- `nv_violation_below_app_clock` (unit: `sec`)
+- `nv_violation_below_base_clock` (unit: `sec`)
+- `nv_nvlink_crc_flit_errors`
+- `nv_nvlink_crc_errors`
+- `nv_nvlink_ecc_errors`
+- `nv_nvlink_replay_errors`
+- `nv_nvlink_recovery_errors`
+- `nv_nvlink_crc_flit_errors_sum`
+- `nv_nvlink_crc_errors_sum`
+- `nv_nvlink_ecc_errors_sum`
+- `nv_nvlink_replay_errors_sum`
+- `nv_nvlink_recovery_errors_sum`
+
+#### Differential Metrics (requires `send_diff_values: true`)
+- `nv_ecc_uncorrected_error_diff`
+- `nv_ecc_corrected_error_diff`
+- `nv_remapped_rows_corrected_diff`
+- `nv_remapped_rows_uncorrected_diff`
+- `nv_remapped_rows_pending_diff`
+- `nv_remapped_rows_failure_diff`
+- `nv_violation_power_diff` (unit: `sec`)
+- `nv_violation_thermal_diff` (unit: `sec`)
+- `nv_violation_sync_boost_diff` (unit: `sec`)
+- `nv_violation_board_limit_diff` (unit: `sec`)
+- `nv_violation_low_util_diff` (unit: `sec`)
+- `nv_violation_reliability_diff` (unit: `sec`)
+- `nv_violation_below_app_clock_diff` (unit: `sec`)
+- `nv_violation_below_base_clock_diff` (unit: `sec`)
+- `nv_nvlink_crc_flit_errors_diff`
+- `nv_nvlink_crc_errors_diff`
+- `nv_nvlink_ecc_errors_diff`
+- `nv_nvlink_replay_errors_diff`
+- `nv_nvlink_recovery_errors_diff`
+- `nv_nvlink_crc_flit_errors_sum_diff`
+- `nv_nvlink_crc_errors_sum_diff`
+- `nv_nvlink_ecc_errors_sum_diff`
+- `nv_nvlink_replay_errors_sum_diff`
+- `nv_nvlink_recovery_errors_sum_diff`

--- a/collectors/raplMetric.go
+++ b/collectors/raplMetric.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
+	lp "github.com/ClusterCockpit/cc-lib/pkg/ccMessage"
 	cclog "github.com/ClusterCockpit/cc-metric-collector/pkg/ccLogger"
-	lp "github.com/ClusterCockpit/cc-energy-manager/pkg/cc-message"
 )
 
 // running average power limit (RAPL) monitoring attributes for a zone

--- a/collectors/raplMetric.md
+++ b/collectors/raplMetric.md
@@ -15,4 +15,4 @@ The Likwid metric collector provides similar functionality.
 
 ## Metrics
 
-* `rapl_average_power`: average power consumption in Watt. The average is computed over the entire runtime from the last measurement to the current measurement
+- `rapl_average_power`: average power consumption in Watt. The average is computed over the entire runtime from the last measurement to the current measurement

--- a/collectors/rocmsmiMetric.go
+++ b/collectors/rocmsmiMetric.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	lp "github.com/ClusterCockpit/cc-lib/pkg/ccMessage"
 	cclog "github.com/ClusterCockpit/cc-metric-collector/pkg/ccLogger"
-	lp "github.com/ClusterCockpit/cc-energy-manager/pkg/cc-message"
 	"github.com/ClusterCockpit/go-rocm-smi/pkg/rocm_smi"
 )
 

--- a/collectors/rocmsmiMetric.md
+++ b/collectors/rocmsmiMetric.md
@@ -1,4 +1,3 @@
-
 ## `rocm_smi` collector
 
 ```json
@@ -24,24 +23,24 @@ Optionally, it is possible to add the serial to the meta informations. They are 
 
 
 Metrics:
-* `rocm_gfx_util`
-* `rocm_umc_util`
-* `rocm_mm_util`
-* `rocm_avg_power`
-* `rocm_temp_mem`
-* `rocm_temp_hotspot`
-* `rocm_temp_edge`
-* `rocm_temp_vrgfx`
-* `rocm_temp_vrsoc`
-* `rocm_temp_vrmem`
-* `rocm_gfx_clock`
-* `rocm_soc_clock`
-* `rocm_u_clock`
-* `rocm_v0_clock`
-* `rocm_v1_clock`
-* `rocm_d0_clock`
-* `rocm_d1_clock`
-* `rocm_temp_hbm`
+- `rocm_gfx_util`
+- `rocm_umc_util`
+- `rocm_mm_util`
+- `rocm_avg_power`
+- `rocm_temp_mem`
+- `rocm_temp_hotspot`
+- `rocm_temp_edge`
+- `rocm_temp_vrgfx`
+- `rocm_temp_vrsoc`
+- `rocm_temp_vrmem`
+- `rocm_gfx_clock`
+- `rocm_soc_clock`
+- `rocm_u_clock`
+- `rocm_v0_clock`
+- `rocm_v1_clock`
+- `rocm_d0_clock`
+- `rocm_d1_clock`
+- `rocm_temp_hbm`
 
 
 Some metrics add the additional sub type tag (`stype`) like the `rocm_temp_hbm` metrics set `stype=device,stype-id=<HBM_slice_number>`. 

--- a/collectors/sampleMetric.go
+++ b/collectors/sampleMetric.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
-	lp "github.com/ClusterCockpit/cc-energy-manager/pkg/cc-message"
+	lp "github.com/ClusterCockpit/cc-lib/pkg/ccMessage"
 	cclog "github.com/ClusterCockpit/cc-metric-collector/pkg/ccLogger"
 )
 

--- a/collectors/sampleTimerMetric.go
+++ b/collectors/sampleTimerMetric.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	lp "github.com/ClusterCockpit/cc-energy-manager/pkg/cc-message"
+	lp "github.com/ClusterCockpit/cc-lib/pkg/ccMessage"
 	cclog "github.com/ClusterCockpit/cc-metric-collector/pkg/ccLogger"
 )
 

--- a/collectors/schedstatMetric.go
+++ b/collectors/schedstatMetric.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
+	lp "github.com/ClusterCockpit/cc-lib/ccMessage"
 	cclog "github.com/ClusterCockpit/cc-metric-collector/pkg/ccLogger"
-	lp "github.com/ClusterCockpit/cc-energy-manager/pkg/cc-message"
 )
 
 const SCHEDSTATFILE = `/proc/schedstat`

--- a/collectors/schedstatMetric.md
+++ b/collectors/schedstatMetric.md
@@ -1,4 +1,3 @@
-
 ## `schedstat` collector
 ```json
   "schedstat": {
@@ -8,4 +7,4 @@
 The `schedstat` collector reads data from /proc/schedstat and calculates a load value, separated by hwthread. This might be useful to detect bad cpu pinning on shared nodes etc. 
 
 Metric:
-* `cpu_load_core`
+- `cpu_load_core`

--- a/collectors/selfMetric.go
+++ b/collectors/selfMetric.go
@@ -6,8 +6,8 @@ import (
 	"syscall"
 	"time"
 
+	lp "github.com/ClusterCockpit/cc-lib/pkg/ccMessage"
 	cclog "github.com/ClusterCockpit/cc-metric-collector/pkg/ccLogger"
-	lp "github.com/ClusterCockpit/cc-energy-manager/pkg/cc-message"
 )
 
 type SelfCollectorConfig struct {

--- a/collectors/selfMetric.md
+++ b/collectors/selfMetric.md
@@ -9,10 +9,10 @@
   }
 ```
 
-The `self` collector reads the data from the `runtime` and `syscall` packages, so monitors the execution of the cc-metric-collector itself.
+The `self` collector reads the data from the `runtime` and `syscall` packages, so it monitors the execution of the cc-metric-collector itself.
 
 Metrics:
-* If `read_mem_stats == true`:
+- If `read_mem_stats == true`:
   * `total_alloc`: The metric reports cumulative bytes allocated for heap objects.
   * `heap_alloc`: The metric reports bytes of allocated heap objects.
   * `heap_sys`: The metric reports bytes of heap memory obtained from the OS.
@@ -20,11 +20,11 @@ Metrics:
   * `heap_inuse`: The metric reports bytes in in-use spans.
   * `heap_released`: The metric reports bytes of physical memory returned to the OS.
   * `heap_objects`: The metric reports the number of allocated heap objects.
-* If `read_goroutines == true`:
+- If `read_goroutines == true`:
   * `num_goroutines`: The metric reports the number of goroutines that currently exist.
-* If `read_cgo_calls == true`:
+- If `read_cgo_calls == true`:
   * `num_cgo_calls`: The metric reports the number of cgo calls made by the current process.
-* If `read_rusage == true`:
+- If `read_rusage == true`:
   * `rusage_user_time`: The metric reports the amount of time that this process has been scheduled in user mode.
   * `rusage_system_time`: The metric reports the amount of time that this process has been scheduled in kernel mode.
   * `rusage_vol_ctx_switch`: The metric reports the amount of voluntary context switches.

--- a/collectors/tempMetric.md
+++ b/collectors/tempMetric.md
@@ -1,22 +1,35 @@
+## tempstat collector
 
-## `tempstat` collector
-
-```json
+```json{
   "tempstat": {
-    "tag_override" : {
-        "<device like hwmon1>" : {
-            "type" : "socket",
-            "type-id" : "0"
+    "tag_override": {
+        "<device identifier>": {
+            "type": "socket",
+            "type-id": "0"
         }
     },
     "exclude_metrics": [
       "metric1",
       "metric2"
-    ]
+    ],
+    "only_metrics": [
+      "temp_core_0",
+      "temp_core_1"
+    ],
+    "report_max_temperature": true,
+    "report_critical_temperature": true
   }
 ```
 
-The `tempstat` collector reads the data from `/sys/class/hwmon/<device>/tempX_{input,label}`
+The `tempstat` collector reads the data from `/sys/class/hwmon/<device>/tempX_{input,label}`.
+
+Both filtering mechanisms are supported:
+- `exclude_metrics`: Excludes the specified metrics.
+- `only_metrics`: If provided, only the listed metrics are collected. This takes precedence over `exclude_metrics`.
 
 Metrics:
-* `temp_*`: The metric name is taken from the `label` files.
+- `temp_*`: The metric name is taken from the label files.
+
+Optional additional metrics:
+- **Max Temperature:** If `report_max_temperature` is enabled, the collector also reads the maximum temperature from the corresponding `_max` file. The metric name is derived by replacing "temp" with "max_temp" in the sensor's metric name.
+- **Critical Temperature:** If `report_critical_temperature` is enabled, the collector also reads the critical temperature from the corresponding `_crit` file. The metric name is derived by replacing "temp" with "crit_temp" in the sensor's metric name.

--- a/collectors/topprocsMetric.go
+++ b/collectors/topprocsMetric.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	lp "github.com/ClusterCockpit/cc-energy-manager/pkg/cc-message"
+	lp "github.com/ClusterCockpit/cc-lib/ccMessage"
 )
 
 const MAX_NUM_PROCS = 10

--- a/collectors/topprocsMetric.md
+++ b/collectors/topprocsMetric.md
@@ -1,4 +1,3 @@
-
 ## `topprocs` collector
 
 ```json
@@ -10,6 +9,3 @@
 The `topprocs` collector reads the TopX processes (sorted by CPU utilization, `ps -Ao comm --sort=-pcpu`). 
 
 In contrast to most other collectors, the metric value is a `string`.
-
-
-

--- a/receivers/natsReceiver.go
+++ b/receivers/natsReceiver.go
@@ -91,17 +91,18 @@ func (r *NatsReceiver) _NatsReceive(m *nats.Msg) {
 				return
 			}
 
-			y, _ := lp.NewMessage(
+			y, err := lp.NewMessage(
 				string(measurement),
 				tags,
 				nil,
 				fields,
 				t,
 			)
-
-			m, err := r.mp.ProcessMessage(y)
-			if err == nil && m != nil {
-				r.sink <- m
+			if err == nil {
+				m, err := r.mp.ProcessMessage(y)
+				if err == nil && m != nil && r.sink != nil {
+					r.sink <- m
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR introduces `only_metrics` filtering logic in `collectors.json` for all testable collectors. It takes precedence over `exclude_metrics`. When set, only the specified metrics are forwarded to the sink, providing better control and visibility over collected metrics. This is particularly useful for collectors with a high number of metrics, where including only the needed metrics is more practical than excluding a large number of unwanted ones.

No breaking changes are introduced.

### Bugfixes:
- `nvidia` collector: Now reads max clocks for `nv_max_graphics_clock` instead of the actual clock.
- `ipmi` collector: Now checks for `ipmitool` presence with `ipmitool -V`, as `ipmitool` alone did not return exit status 0.
- `cpufreq` collector: Now reports clock speeds in MHz instead of GHz.

### Enhancements:
- `nvidia` collector:
  - Added support for multiple fans; if detected, fan speeds for all fans are reported.
  - Added support for `memory_info_v2`, splitting `nv_mem_reserved` from `nv_mem_used`.
- `temp` collector: Added `max` and `critical` temperature metrics.

### Diff and Derived Values:
- Added support for differential (`_diff`) and derived (`_rate`) metrics to `nvidia`, `numastats`, `nfsiostat`, `nfsstat` (`nfs3stat` and `nfs4stat`), `iostat`, and `customcmd`.
- Absolute values remain enabled by default, ensuring compatibility with existing configurations.

### README Updates:
- Metrics are now sorted into categories for better readability.
- Removed obsolete `ibstat_perfquery` reference.

### Documentation (*.md files):
- Standardized the format of metric lists across all files for consistency (using `-` for list items).
- Clarified filter logic for `nfsstat` (`nfs3stat` and `nfs4stat`), `nfsiostat`, and `lustrestat`.

### Removals:
- Removed `exclude_metrics` from the `cpufreq` collector, as it only collects a single metric.