### PR TITLE
Use timer_getCycleClock in likwidMetric

### DIFF
--- a/collectors/likwidMetric.go
+++ b/collectors/likwidMetric.go
@@ -190,12 +190,8 @@ func getBaseFreq() float64 {
 	}
 
 	if math.IsNaN(freq) {
-		C.power_init(0)
-		info := C.get_powerInfo()
-		if float64(info.baseFrequency) != 0 {
-			freq = float64(info.baseFrequency)
-		}
-		C.power_finalize()
+		C.timer_init()
+		freq = float64(C.timer_getCycleClock()) / 1e3
 	}
 	return freq * 1e3
 }


### PR DESCRIPTION
If the system does not provide the base CPU frequency through sysfs, it uses LIKWID's base frequency value out of the power module but misses the conversion from `MHz` to `HZ` thus calculations using `inverseClock` in expressions are wrong.