### PR TITLE
Read written bytes instead of read bytes

### DIFF
--- a/collectors/gpfsMetric.go
+++ b/collectors/gpfsMetric.go
@@ -278,7 +278,7 @@ func (m *GpfsCollector) Read(interval time.Duration, output chan lp.CCMessage) {
 			output <- y
 		}
 		if m.config.SendBandwidths {
-			if lastBytesWritten := m.lastState[filesystem].bytesRead; lastBytesWritten >= 0 {
+			if lastBytesWritten := m.lastState[filesystem].bytesWritten; lastBytesWritten >= 0 {
 				bwWrite := float64(bytesWritten-lastBytesWritten) / timeDiff
 				if y, err :=
 					lp.NewMessage(


### PR DESCRIPTION
The metric gpfs_bw_write reads byteRead when calculating the amount of trandferred data. This leads to incorrect values regarding the gpfs_bw_write metric. 