### PR TITLE
CI: Install libdrm-dev for building (required on Ubuntu)

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -270,7 +270,7 @@ jobs:
     - name: Install development packages
       run: |
           apt update && apt --assume-yes upgrade
-          apt --assume-yes install build-essential sed git wget bash
+          apt --assume-yes install build-essential sed git wget bash libdrm-dev
     # Checkout git repository and submodules
     # fetch-depth must be 0 to use git describe
     # See: https://github.com/marketplace/actions/checkout
@@ -321,7 +321,7 @@ jobs:
     - name: Install development packages
       run: |
           apt update && apt --assume-yes upgrade
-          apt --assume-yes install build-essential sed git wget bash
+          apt --assume-yes install build-essential sed git wget bash libdrm-dev
     # Checkout git repository and submodules
     # fetch-depth must be 0 to use git describe
     # See: https://github.com/marketplace/actions/checkout

--- a/scripts/cc-metric-collector.deb.control
+++ b/scripts/cc-metric-collector.deb.control
@@ -6,7 +6,7 @@ Installed-Size: {INSTALLED_SIZE}
 Architecture: {ARCH}
 Maintainer: thomas.gruber@fau.de
 Depends: libc6 (>= 2.2.1)
-Build-Depends: debhelper-compat (= 13), git, golang-go
+Build-Depends: debhelper-compat (= 13), git, golang-go, libdrm-dev
 Description: Metric collection daemon from the ClusterCockpit suite
 Homepage: https://github.com/ClusterCockpit/cc-metric-collector
 Source: cc-metric-collector


### PR DESCRIPTION
Fixes a build error about missing libdrm/drm.h header.