### PR TITLE
Fix Overflows in Infiniband collector

### DIFF
--- a/collectors/infinibandMetric.go
+++ b/collectors/infinibandMetric.go
@@ -30,6 +30,7 @@ type InfinibandCollectorMetric struct {
 	name               string
 	path               string
 	unit               string
+	unitRates          string
 	scaleByFourLanes   bool
 	addToIBTotal       bool
 	addToIBTotalPkgs   bool
@@ -129,6 +130,7 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 				name:             "ib_recv",
 				path:             filepath.Join(countersDir, "port_rcv_data"),
 				unit:             "bytes/4",
+				unitRates:        "bytes/sec",
 				scaleByFourLanes: true,
 				addToIBTotal:     true,
 			},
@@ -138,6 +140,7 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 				name:             "ib_xmit",
 				path:             filepath.Join(countersDir, "port_xmit_data"),
 				unit:             "bytes/4",
+				unitRates:        "bytes/sec",
 				scaleByFourLanes: true,
 				addToIBTotal:     true,
 			},
@@ -147,6 +150,7 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 				name:             "ib_recv_pkts",
 				path:             filepath.Join(countersDir, "port_rcv_packets"),
 				unit:             "packets",
+				unitRates:        "packets/sec",
 				addToIBTotalPkgs: true,
 			},
 			{
@@ -155,6 +159,7 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 				name:             "ib_xmit_pkts",
 				path:             filepath.Join(countersDir, "port_xmit_packets"),
 				unit:             "packets",
+				unitRates:        "packets/sec",
 				addToIBTotalPkgs: true,
 			},
 		}
@@ -205,9 +210,9 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 	for i := range m.info {
 		info := &m.info[i]
 
-		var ib_total, ib_total_last_state,
-			ib_total_pkts, ib_total_pkts_last_state uint64
-		var ib_total_last_state_available, ib_total_pkts_last_state_available bool
+		var ib_total, ib_total_pkts uint64        // sum of xmit and recv counters
+		var ib_total_bw, ib_total_pkts_bw float64 // sum of xmit and recv rates
+		var ib_total_bw_available, ib_total_pkts_bw_available bool
 		for i := range info.portCounterFiles {
 			counterDef := &info.portCounterFiles[i]
 
@@ -246,19 +251,19 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 						rate *= float64(4)
 					}
 					if y, err := lp.NewMetric(counterDef.name+"_bw", info.tagSet, m.meta, rate, now); err == nil {
-						y.AddMeta("unit", counterDef.unit+"/sec")
+						y.AddMeta("unit", counterDef.unitRates)
 						output <- y
 					}
 
-					// Sum up total values of last state
+					// Sum up rates for total rates
 					if m.config.SendTotalValues {
 						switch {
 						case counterDef.addToIBTotal:
-							ib_total_last_state += counterDef.lastState
-							ib_total_last_state_available = true
+							ib_total_bw += rate
+							ib_total_bw_available = true
 						case counterDef.addToIBTotalPkgs:
-							ib_total_pkts_last_state += counterDef.lastState
-							ib_total_pkts_last_state_available = true
+							ib_total_pkts_bw += rate
+							ib_total_pkts_bw_available = true
 						}
 					}
 				}
@@ -289,18 +294,15 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 				output <- y
 			}
 
-			if m.config.SendDerivedValues && ib_total_last_state_available {
-				rate := float64((ib_total - ib_total_last_state)) / timeDiff
-				rate *= float64(4)
-				if y, err := lp.NewMetric("ib_total_bw", info.tagSet, m.meta, rate, now); err == nil {
+			if m.config.SendDerivedValues && ib_total_bw_available {
+				if y, err := lp.NewMetric("ib_total_bw", info.tagSet, m.meta, ib_total_bw, now); err == nil {
 					y.AddMeta("unit", "bytes/sec")
 					output <- y
 				}
 			}
 
-			if m.config.SendDerivedValues && ib_total_pkts_last_state_available {
-				rate := float64((ib_total_pkts - ib_total_pkts_last_state)) / timeDiff
-				if y, err := lp.NewMetric("ib_total_pkts_bw", info.tagSet, m.meta, rate, now); err == nil {
+			if m.config.SendDerivedValues && ib_total_pkts_bw_available {
+				if y, err := lp.NewMetric("ib_total_pkts_bw", info.tagSet, m.meta, ib_total_pkts_bw, now); err == nil {
 					y.AddMeta("unit", "packets/sec")
 					output <- y
 				}

--- a/collectors/infinibandMetric.go
+++ b/collectors/infinibandMetric.go
@@ -27,13 +27,14 @@ import (
 const IB_BASEPATH = "/sys/class/infiniband/"
 
 type InfinibandCollectorMetric struct {
-	name             string
-	path             string
-	unit             string
-	scale            int64
-	addToIBTotal     bool
-	addToIBTotalPkgs bool
-	lastState        int64
+	name               string
+	path               string
+	unit               string
+	scale              uint64
+	addToIBTotal       bool
+	addToIBTotalPkgs   bool
+	lastState          uint64
+	lastStateAvailable bool
 }
 
 type InfinibandCollectorInfo struct {
@@ -130,7 +131,6 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 				unit:         "bytes",
 				scale:        4,
 				addToIBTotal: true,
-				lastState:    -1,
 			},
 			{
 				// Total number of data octets, divided by 4 (lanes), transmitted on all VLs.
@@ -140,7 +140,6 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 				unit:         "bytes",
 				scale:        4,
 				addToIBTotal: true,
-				lastState:    -1,
 			},
 			{
 				// Total number of packets received on all VLs from this port (this may include packets containing Errors.
@@ -150,7 +149,6 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 				unit:             "packets",
 				scale:            1,
 				addToIBTotalPkgs: true,
-				lastState:        -1,
 			},
 			{
 				// Total number of packets transmitted on all VLs from this port. This may include packets with errors.
@@ -160,7 +158,6 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 				unit:             "packets",
 				scale:            1,
 				addToIBTotalPkgs: true,
-				lastState:        -1,
 			},
 		}
 		for _, counter := range portCounterFiles {
@@ -211,7 +208,7 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 		info := &m.info[i]
 
 		var ib_total, ib_total_last_state,
-			ib_total_pkts, ib_total_pkts_last_state int64
+			ib_total_pkts, ib_total_pkts_last_state uint64
 		var ib_total_last_state_available, ib_total_pkts_last_state_available bool
 		for i := range info.portCounterFiles {
 			counterDef := &info.portCounterFiles[i]
@@ -226,8 +223,8 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 			}
 			data := strings.TrimSpace(string(line))
 
-			// convert counter to int64
-			v, err := strconv.ParseInt(data, 10, 64)
+			// convert counter to uint64
+			v, err := strconv.ParseUint(data, 10, 64)
 			if err != nil {
 				cclog.ComponentError(
 					m.name,
@@ -247,7 +244,7 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 
 			// Send derived values
 			if m.config.SendDerivedValues {
-				if counterDef.lastState >= 0 {
+				if counterDef.lastStateAvailable {
 					rate := float64((v - counterDef.lastState)) / timeDiff
 					if y, err := lp.NewMetric(counterDef.name+"_bw", info.tagSet, m.meta, rate, now); err == nil {
 						y.AddMeta("unit", counterDef.unit+"/sec")
@@ -267,6 +264,7 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 					}
 				}
 				counterDef.lastState = v
+				counterDef.lastStateAvailable = true
 			}
 
 			// Sum up total values

--- a/collectors/infinibandMetric.go
+++ b/collectors/infinibandMetric.go
@@ -30,7 +30,7 @@ type InfinibandCollectorMetric struct {
 	name               string
 	path               string
 	unit               string
-	scale              uint64
+	scaleByFourLanes   bool
 	addToIBTotal       bool
 	addToIBTotalPkgs   bool
 	lastState          uint64
@@ -126,20 +126,20 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 			{
 				// Total number of data octets, divided by 4 (lanes), received on all VLs.
 				// This is 64 bit counter
-				name:         "ib_recv",
-				path:         filepath.Join(countersDir, "port_rcv_data"),
-				unit:         "bytes",
-				scale:        4,
-				addToIBTotal: true,
+				name:             "ib_recv",
+				path:             filepath.Join(countersDir, "port_rcv_data"),
+				unit:             "bytes/4",
+				scaleByFourLanes: true,
+				addToIBTotal:     true,
 			},
 			{
 				// Total number of data octets, divided by 4 (lanes), transmitted on all VLs.
 				// This is 64 bit counter
-				name:         "ib_xmit",
-				path:         filepath.Join(countersDir, "port_xmit_data"),
-				unit:         "bytes",
-				scale:        4,
-				addToIBTotal: true,
+				name:             "ib_xmit",
+				path:             filepath.Join(countersDir, "port_xmit_data"),
+				unit:             "bytes/4",
+				scaleByFourLanes: true,
+				addToIBTotal:     true,
 			},
 			{
 				// Total number of packets received on all VLs from this port (this may include packets containing Errors.
@@ -147,7 +147,6 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 				name:             "ib_recv_pkts",
 				path:             filepath.Join(countersDir, "port_rcv_packets"),
 				unit:             "packets",
-				scale:            1,
 				addToIBTotalPkgs: true,
 			},
 			{
@@ -156,7 +155,6 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 				name:             "ib_xmit_pkts",
 				path:             filepath.Join(countersDir, "port_xmit_packets"),
 				unit:             "packets",
-				scale:            1,
 				addToIBTotalPkgs: true,
 			},
 		}
@@ -231,8 +229,6 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 					fmt.Sprintf("Read(): Failed to convert Infininiband metrice %s='%s' to int64: %v", counterDef.name, data, err))
 				continue
 			}
-			// Scale raw value
-			v *= counterDef.scale
 
 			// Send absolut values
 			if m.config.SendAbsoluteValues {
@@ -246,6 +242,9 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 			if m.config.SendDerivedValues {
 				if counterDef.lastStateAvailable {
 					rate := float64((v - counterDef.lastState)) / timeDiff
+					if counterDef.scaleByFourLanes {
+						rate *= float64(4)
+					}
 					if y, err := lp.NewMetric(counterDef.name+"_bw", info.tagSet, m.meta, rate, now); err == nil {
 						y.AddMeta("unit", counterDef.unit+"/sec")
 						output <- y
@@ -281,7 +280,7 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 		// Send total values
 		if m.config.SendTotalValues {
 			if y, err := lp.NewMetric("ib_total", info.tagSet, m.meta, ib_total, now); err == nil {
-				y.AddMeta("unit", "bytes")
+				y.AddMeta("unit", "bytes/4")
 				output <- y
 			}
 
@@ -292,6 +291,7 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 
 			if m.config.SendDerivedValues && ib_total_last_state_available {
 				rate := float64((ib_total - ib_total_last_state)) / timeDiff
+				rate *= float64(4)
 				if y, err := lp.NewMetric("ib_total_bw", info.tagSet, m.meta, rate, now); err == nil {
 					y.AddMeta("unit", "bytes/sec")
 					output <- y

--- a/collectors/infinibandMetric.go
+++ b/collectors/infinibandMetric.go
@@ -26,11 +26,11 @@ import (
 
 // See: https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-class-infiniband
 const (
-	IB_BASEPATH    = "/sys/class/infiniband/"
-	IBdataUnit     = "bytes"
-	IBdataRateUnit = IBdataUnit + "/sec"
-	IBpkgUnit      = "packets"
-	IBpkgRateUnit  = IBpkgUnit + "/sec"
+	ibBasePath     = "/sys/class/infiniband/"
+	ibDataUnit     = "bytes"
+	ibDataRateUnit = ibDataUnit + "/sec"
+	ibPkgUnit      = "packets"
+	ibPkgRateUnit  = ibPkgUnit + "/sec"
 )
 
 type InfinibandCollectorMetric struct {
@@ -46,7 +46,7 @@ type InfinibandCollectorMetric struct {
 }
 
 type InfinibandCollectorInfo struct {
-	LID              string                      // IB local Identifier (LID)
+	lid              string                      // IB local Identifier (LID)
 	device           string                      // IB device
 	port             string                      // IB device port
 	portCounterFiles []InfinibandCollectorMetric // mapping counter name -> InfinibandCollectorMetric
@@ -66,7 +66,7 @@ type InfinibandCollector struct {
 	lastTimestamp time.Time // Store time stamp of last tick to derive bandwidths
 }
 
-// Init initializes the Infiniband collector by walking through files below IB_BASEPATH
+// Init initializes the Infiniband collector by walking through files below ibBasePath
 func (m *InfinibandCollector) Init(config json.RawMessage) error {
 	// Check if already initialized
 	if m.init {
@@ -97,7 +97,7 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 	}
 
 	// Loop for all InfiniBand directories
-	globPattern := filepath.Join(IB_BASEPATH, "*", "ports", "*")
+	globPattern := filepath.Join(ibBasePath, "*", "ports", "*")
 	ibDirs, err := filepath.Glob(globPattern)
 	if err != nil {
 		return fmt.Errorf("%s Init(): unable to glob files with pattern %s: %w", m.name, globPattern, err)
@@ -136,8 +136,8 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 				// This is 64 bit counter
 				name:             "ib_recv",
 				path:             filepath.Join(countersDir, "port_rcv_data"),
-				unit:             IBdataUnit,
-				unitRates:        IBdataRateUnit,
+				unit:             ibDataUnit,
+				unitRates:        ibDataRateUnit,
 				scaleByFourLanes: true,
 				addToIBTotal:     true,
 			},
@@ -146,8 +146,8 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 				// This is 64 bit counter
 				name:             "ib_xmit",
 				path:             filepath.Join(countersDir, "port_xmit_data"),
-				unit:             IBdataUnit,
-				unitRates:        IBdataRateUnit,
+				unit:             ibDataUnit,
+				unitRates:        ibDataRateUnit,
 				scaleByFourLanes: true,
 				addToIBTotal:     true,
 			},
@@ -156,8 +156,8 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 				// This is 64 bit counter.
 				name:             "ib_recv_pkts",
 				path:             filepath.Join(countersDir, "port_rcv_packets"),
-				unit:             IBpkgUnit,
-				unitRates:        IBpkgRateUnit,
+				unit:             ibPkgUnit,
+				unitRates:        ibPkgRateUnit,
 				addToIBTotalPkgs: true,
 			},
 			{
@@ -165,8 +165,8 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 				// This is 64 bit counter.
 				name:             "ib_xmit_pkts",
 				path:             filepath.Join(countersDir, "port_xmit_packets"),
-				unit:             IBpkgUnit,
-				unitRates:        IBpkgRateUnit,
+				unit:             ibPkgUnit,
+				unitRates:        ibPkgRateUnit,
 				addToIBTotalPkgs: true,
 			},
 		}
@@ -179,7 +179,7 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 
 		m.info = append(m.info,
 			InfinibandCollectorInfo{
-				LID:              LID,
+				lid:              LID,
 				device:           device,
 				port:             port,
 				portCounterFiles: portCounterFiles,
@@ -200,7 +200,7 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 	return nil
 }
 
-// Read reads Infiniband counter files below IB_BASEPATH
+// Read reads Infiniband counter files below ibBasePath
 func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMessage) {
 	// Check if already initialized
 	if !m.init {
@@ -217,9 +217,9 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 	for i := range m.info {
 		info := &m.info[i]
 
-		var ib_total, ib_total_pkts uint64        // sum of xmit and recv counters
-		var ib_total_bw, ib_total_pkts_bw float64 // sum of xmit and recv rates
-		var ib_total_bw_available, ib_total_pkts_bw_available bool
+		var ibTotal, ibTotalPkts uint64      // sum of xmit and recv counters
+		var ibTotalBw, ibTotalPktsBw float64 // sum of xmit and recv rates
+		var ibTotalBwAvailable, ibTotalPktsBwAvailable bool
 		for i := range info.portCounterFiles {
 			counterDef := &info.portCounterFiles[i]
 
@@ -280,11 +280,11 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 					if m.config.SendTotalValues {
 						switch {
 						case counterDef.addToIBTotal:
-							ib_total_bw += rate
-							ib_total_bw_available = true
+							ibTotalBw += rate
+							ibTotalBwAvailable = true
 						case counterDef.addToIBTotalPkgs:
-							ib_total_pkts_bw += rate
-							ib_total_pkts_bw_available = true
+							ibTotalPktsBw += rate
+							ibTotalPktsBwAvailable = true
 						}
 					}
 				}
@@ -296,35 +296,35 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 			if m.config.SendTotalValues {
 				switch {
 				case counterDef.addToIBTotal:
-					ib_total += vScaledCounter
+					ibTotal += vScaledCounter
 				case counterDef.addToIBTotalPkgs:
-					ib_total_pkts += vScaledCounter
+					ibTotalPkts += vScaledCounter
 				}
 			}
 		}
 
 		// Send total values
 		if m.config.SendTotalValues {
-			if y, err := lp.NewMetric("ib_total", info.tagSet, m.meta, ib_total, now); err == nil {
-				y.AddMeta("unit", IBdataUnit)
+			if y, err := lp.NewMetric("ib_total", info.tagSet, m.meta, ibTotal, now); err == nil {
+				y.AddMeta("unit", ibDataUnit)
 				output <- y
 			}
 
-			if y, err := lp.NewMetric("ib_total_pkts", info.tagSet, m.meta, ib_total_pkts, now); err == nil {
-				y.AddMeta("unit", IBpkgUnit)
+			if y, err := lp.NewMetric("ib_total_pkts", info.tagSet, m.meta, ibTotalPkts, now); err == nil {
+				y.AddMeta("unit", ibPkgUnit)
 				output <- y
 			}
 
-			if m.config.SendDerivedValues && ib_total_bw_available {
-				if y, err := lp.NewMetric("ib_total_bw", info.tagSet, m.meta, ib_total_bw, now); err == nil {
-					y.AddMeta("unit", IBdataRateUnit)
+			if m.config.SendDerivedValues && ibTotalBwAvailable {
+				if y, err := lp.NewMetric("ib_total_bw", info.tagSet, m.meta, ibTotalBw, now); err == nil {
+					y.AddMeta("unit", ibDataRateUnit)
 					output <- y
 				}
 			}
 
-			if m.config.SendDerivedValues && ib_total_pkts_bw_available {
-				if y, err := lp.NewMetric("ib_total_pkts_bw", info.tagSet, m.meta, ib_total_pkts_bw, now); err == nil {
-					y.AddMeta("unit", IBpkgRateUnit)
+			if m.config.SendDerivedValues && ibTotalPktsBwAvailable {
+				if y, err := lp.NewMetric("ib_total_pkts_bw", info.tagSet, m.meta, ibTotalPktsBw, now); err == nil {
+					y.AddMeta("unit", ibPkgRateUnit)
 					output <- y
 				}
 			}

--- a/collectors/infinibandMetric.go
+++ b/collectors/infinibandMetric.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"slices"
@@ -246,7 +247,13 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 			// Send derived values
 			if m.config.SendDerivedValues {
 				if counterDef.lastStateAvailable {
-					rate := float64((v - counterDef.lastState)) / timeDiff
+					var rate float64
+					if v >= counterDef.lastState {
+						rate = float64(v-counterDef.lastState) / timeDiff
+					} else {
+						// Counter wrap around
+						rate = float64(math.MaxUint64-counterDef.lastState+v+1) / timeDiff
+					}
 					if counterDef.scaleByFourLanes {
 						rate *= float64(4)
 					}

--- a/collectors/infinibandMetric.go
+++ b/collectors/infinibandMetric.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// See: https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-class-infiniband
 const IB_BASEPATH = "/sys/class/infiniband/"
 
 type InfinibandCollectorMetric struct {
@@ -122,6 +123,8 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 		countersDir := filepath.Join(path, "counters")
 		portCounterFiles := []InfinibandCollectorMetric{
 			{
+				// Total number of data octets, divided by 4 (lanes), received on all VLs.
+				// This is 64 bit counter
 				name:         "ib_recv",
 				path:         filepath.Join(countersDir, "port_rcv_data"),
 				unit:         "bytes",
@@ -130,6 +133,8 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 				lastState:    -1,
 			},
 			{
+				// Total number of data octets, divided by 4 (lanes), transmitted on all VLs.
+				// This is 64 bit counter
 				name:         "ib_xmit",
 				path:         filepath.Join(countersDir, "port_xmit_data"),
 				unit:         "bytes",
@@ -138,6 +143,8 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 				lastState:    -1,
 			},
 			{
+				// Total number of packets received on all VLs from this port (this may include packets containing Errors.
+				// This is 64 bit counter.
 				name:             "ib_recv_pkts",
 				path:             filepath.Join(countersDir, "port_rcv_packets"),
 				unit:             "packets",
@@ -146,6 +153,8 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 				lastState:        -1,
 			},
 			{
+				// Total number of packets transmitted on all VLs from this port. This may include packets with errors.
+				// This is 64 bit counter.
 				name:             "ib_xmit_pkts",
 				path:             filepath.Join(countersDir, "port_xmit_packets"),
 				unit:             "packets",

--- a/collectors/infinibandMetric.go
+++ b/collectors/infinibandMetric.go
@@ -229,6 +229,8 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 				cclog.ComponentError(
 					m.name,
 					fmt.Sprintf("Read(): Failed to read from file '%s': %v", counterDef.path, err))
+				// Current counter can not be saved as last state
+				counterDef.lastStateAvailable = false
 				continue
 			}
 			data := strings.TrimSpace(string(line))
@@ -239,6 +241,8 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 				cclog.ComponentError(
 					m.name,
 					fmt.Sprintf("Read(): Failed to convert Infininiband metrice %s='%s' to uint64: %v", counterDef.name, data, err))
+				// Current counter can not be saved as last state
+				counterDef.lastStateAvailable = false
 				continue
 			}
 			vScaledCounter := vRawCounter

--- a/collectors/infinibandMetric.go
+++ b/collectors/infinibandMetric.go
@@ -11,7 +11,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
 	"slices"
@@ -262,12 +261,13 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 			if m.config.SendDerivedValues {
 				if counterDef.lastStateAvailable {
 					var rate float64
-					if vRawCounter >= counterDef.lastState {
-						rate = float64(vRawCounter-counterDef.lastState) / timeDiff
-					} else {
-						// Counter wrap around
-						rate = float64(math.MaxUint64-counterDef.lastState+vRawCounter+1) / timeDiff
-					}
+					// uint64 subtraction handles wraparound automatically
+					// in case vRawCounter < counterDef.lastState we would compute:
+					// math.MaxUint64 - lastState + vRawCounter + 1
+					// = (2^64 - 1) - lastState + vRawCounter + 1
+					// = 2^64 - lastState + vRawCounter
+					// ≡ vRawCounter - lastState (mod 2^64)
+					rate = float64(vRawCounter-counterDef.lastState) / timeDiff
 					if counterDef.scaleByFourLanes {
 						rate *= float64(4)
 					}

--- a/collectors/infinibandMetric.go
+++ b/collectors/infinibandMetric.go
@@ -25,7 +25,13 @@ import (
 )
 
 // See: https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-class-infiniband
-const IB_BASEPATH = "/sys/class/infiniband/"
+const (
+	IB_BASEPATH    = "/sys/class/infiniband/"
+	IBdataUnit     = "bytes"
+	IBdataRateUnit = IBdataUnit + "/sec"
+	IBpkgUnit      = "packets"
+	IBpkgRateUnit  = IBpkgUnit + "/sec"
+)
 
 type InfinibandCollectorMetric struct {
 	name               string
@@ -130,8 +136,8 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 				// This is 64 bit counter
 				name:             "ib_recv",
 				path:             filepath.Join(countersDir, "port_rcv_data"),
-				unit:             "bytes/4",
-				unitRates:        "bytes/sec",
+				unit:             IBdataUnit,
+				unitRates:        IBdataRateUnit
 				scaleByFourLanes: true,
 				addToIBTotal:     true,
 			},
@@ -140,8 +146,8 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 				// This is 64 bit counter
 				name:             "ib_xmit",
 				path:             filepath.Join(countersDir, "port_xmit_data"),
-				unit:             "bytes/4",
-				unitRates:        "bytes/sec",
+				unit:             IBdataUnit,
+				unitRates:        IBdataRateUnit,
 				scaleByFourLanes: true,
 				addToIBTotal:     true,
 			},
@@ -150,8 +156,8 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 				// This is 64 bit counter.
 				name:             "ib_recv_pkts",
 				path:             filepath.Join(countersDir, "port_rcv_packets"),
-				unit:             "packets",
-				unitRates:        "packets/sec",
+				unit:             IBpkgUnit,
+				unitRates:        IBpkgRateUnit,
 				addToIBTotalPkgs: true,
 			},
 			{
@@ -159,8 +165,8 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 				// This is 64 bit counter.
 				name:             "ib_xmit_pkts",
 				path:             filepath.Join(countersDir, "port_xmit_packets"),
-				unit:             "packets",
-				unitRates:        "packets/sec",
+				unit:             IBpkgUnit,
+				unitRates:        IBpkgRateUnit,
 				addToIBTotalPkgs: true,
 			},
 		}
@@ -228,17 +234,21 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 			data := strings.TrimSpace(string(line))
 
 			// convert counter to uint64
-			v, err := strconv.ParseUint(data, 10, 64)
+			vRawCounter, err := strconv.ParseUint(data, 10, 64)
 			if err != nil {
 				cclog.ComponentError(
 					m.name,
-					fmt.Sprintf("Read(): Failed to convert Infininiband metrice %s='%s' to int64: %v", counterDef.name, data, err))
+					fmt.Sprintf("Read(): Failed to convert Infininiband metrice %s='%s' to uint64: %v", counterDef.name, data, err))
 				continue
 			}
 
 			// Send absolut values
 			if m.config.SendAbsoluteValues {
-				if y, err := lp.NewMetric(counterDef.name, info.tagSet, m.meta, v, now); err == nil {
+				vScaledCounter := vRawCounter
+				if counterDef.scaleByFourLanes {
+					vScaledCounter *= uint64(4)
+				}
+				if y, err := lp.NewMetric(counterDef.name, info.tagSet, m.meta, vScaledCounter, now); err == nil {
 					y.AddMeta("unit", counterDef.unit)
 					output <- y
 				}
@@ -248,11 +258,11 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 			if m.config.SendDerivedValues {
 				if counterDef.lastStateAvailable {
 					var rate float64
-					if v >= counterDef.lastState {
-						rate = float64(v-counterDef.lastState) / timeDiff
+					if vRawCounter >= counterDef.lastState {
+						rate = float64(vRawCounter-counterDef.lastState) / timeDiff
 					} else {
 						// Counter wrap around
-						rate = float64(math.MaxUint64-counterDef.lastState+v+1) / timeDiff
+						rate = float64(math.MaxUint64-counterDef.lastState+vRawCounter+1) / timeDiff
 					}
 					if counterDef.scaleByFourLanes {
 						rate *= float64(4)
@@ -274,7 +284,7 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 						}
 					}
 				}
-				counterDef.lastState = v
+				counterDef.lastState = vRawCounter
 				counterDef.lastStateAvailable = true
 			}
 
@@ -282,9 +292,9 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 			if m.config.SendTotalValues {
 				switch {
 				case counterDef.addToIBTotal:
-					ib_total += v
+					ib_total += vRawCounter
 				case counterDef.addToIBTotalPkgs:
-					ib_total_pkts += v
+					ib_total_pkts += vRawCounter
 				}
 			}
 		}
@@ -292,25 +302,25 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 		// Send total values
 		if m.config.SendTotalValues {
 			if y, err := lp.NewMetric("ib_total", info.tagSet, m.meta, ib_total, now); err == nil {
-				y.AddMeta("unit", "bytes/4")
+				y.AddMeta("unit", IBdataUnit)
 				output <- y
 			}
 
 			if y, err := lp.NewMetric("ib_total_pkts", info.tagSet, m.meta, ib_total_pkts, now); err == nil {
-				y.AddMeta("unit", "packets")
+				y.AddMeta("unit", IBpkgUnit)
 				output <- y
 			}
 
 			if m.config.SendDerivedValues && ib_total_bw_available {
 				if y, err := lp.NewMetric("ib_total_bw", info.tagSet, m.meta, ib_total_bw, now); err == nil {
-					y.AddMeta("unit", "bytes/sec")
+					y.AddMeta("unit", IBdataRateUnit)
 					output <- y
 				}
 			}
 
 			if m.config.SendDerivedValues && ib_total_pkts_bw_available {
 				if y, err := lp.NewMetric("ib_total_pkts_bw", info.tagSet, m.meta, ib_total_pkts_bw, now); err == nil {
-					y.AddMeta("unit", "packets/sec")
+					y.AddMeta("unit", IBpkgRateUnit)
 					output <- y
 				}
 			}

--- a/collectors/infinibandMetric.go
+++ b/collectors/infinibandMetric.go
@@ -137,7 +137,7 @@ func (m *InfinibandCollector) Init(config json.RawMessage) error {
 				name:             "ib_recv",
 				path:             filepath.Join(countersDir, "port_rcv_data"),
 				unit:             IBdataUnit,
-				unitRates:        IBdataRateUnit
+				unitRates:        IBdataRateUnit,
 				scaleByFourLanes: true,
 				addToIBTotal:     true,
 			},
@@ -241,13 +241,13 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 					fmt.Sprintf("Read(): Failed to convert Infininiband metrice %s='%s' to uint64: %v", counterDef.name, data, err))
 				continue
 			}
+			vScaledCounter := vRawCounter
+			if counterDef.scaleByFourLanes {
+				vScaledCounter *= uint64(4)
+			}
 
 			// Send absolut values
 			if m.config.SendAbsoluteValues {
-				vScaledCounter := vRawCounter
-				if counterDef.scaleByFourLanes {
-					vScaledCounter *= uint64(4)
-				}
 				if y, err := lp.NewMetric(counterDef.name, info.tagSet, m.meta, vScaledCounter, now); err == nil {
 					y.AddMeta("unit", counterDef.unit)
 					output <- y
@@ -292,9 +292,9 @@ func (m *InfinibandCollector) Read(interval time.Duration, output chan lp.CCMess
 			if m.config.SendTotalValues {
 				switch {
 				case counterDef.addToIBTotal:
-					ib_total += vRawCounter
+					ib_total += vScaledCounter
 				case counterDef.addToIBTotalPkgs:
-					ib_total_pkts += vRawCounter
+					ib_total_pkts += vScaledCounter
 				}
 			}
 		}


### PR DESCRIPTION
Our timeseries database shows multiple overflow events from the counters collected by the Infiniband collector.

* The counters provided by the linux kernel are unsigned 64 bit integers (`__be64`). Using int64 in the collector means we lose one bit of precision.
* Scaling by a factor of 4 results in a further loss of 2 bits of precision.
* Adding two counters can reduce precision by another 1 bit
* The raw counters increase continuously. Therefore, an overflow can be detected when the current counter value is smaller than the previous one.