### PR TITLE
Add filter for ipmi metrics

### DIFF
--- a/collectors/ipmiMetric.go
+++ b/collectors/ipmiMetric.go
@@ -31,10 +31,24 @@ type IpmiCollector struct {
 		IpmitoolPath    string `json:"ipmitool_path"`
 		IpmisensorsPath string `json:"ipmisensors_path"`
 		Sudo            bool   `json:"use_sudo"`
+		IncludeMetrics  []string `json:"include_metrics"`
 	}
 
 	ipmitool    string
 	ipmisensors string
+}
+
+func (m *IpmiCollector) metricIncluded(name string) bool {
+    if len(m.config.IncludeMetrics) == 0 {
+        return true
+    }
+
+    for _, metric := range m.config.IncludeMetrics {
+        if metric == name {
+            return true
+        }
+    }
+    return false
 }
 
 func (m *IpmiCollector) Init(config json.RawMessage) error {
@@ -145,6 +159,11 @@ func (m *IpmiCollector) readIpmiTool(output chan lp.CCMessage) error {
 			continue
 		}
 		name := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(lv[0]), " ", "_"))
+
+		if !m.metricIncluded(name) {
+ 			continue
+		}
+
 		unit := strings.TrimSpace(lv[2])
 		switch unit {
 		case "Volts":
@@ -209,6 +228,11 @@ func (m *IpmiCollector) readIpmiSensors(output chan lp.CCMessage) error {
 			continue
 		}
 		name := strings.ToLower(strings.ReplaceAll(lv[1], " ", "_"))
+
+		if !m.metricIncluded(name) {
+			continue
+		}
+
 		y, err := lp.NewMetric(name, map[string]string{"type": "node"}, m.meta, v, time.Now())
 		if err != nil {
 			cclog.ComponentErrorf(m.name, "Failed to create message: %v", err)

--- a/collectors/ipmiMetric.go
+++ b/collectors/ipmiMetric.go
@@ -66,6 +66,15 @@ func (m *IpmiCollector) Init(config json.RawMessage) error {
 		}
 	}
 
+	// Read metrics to include
+	m.includeMetrics = make(map[string]bool)
+	for _, metric := range m.config.IncludeMetrics {
+		metric = strings.ToLower(strings.TrimSpace(metric))
+		if metric != "" {
+			m.includeMetrics[metric] = true
+		}
+	}
+
 	m.ipmitool = m.config.IpmitoolPath
 	m.ipmisensors = m.config.IpmisensorsPath
 
@@ -107,15 +116,6 @@ func (m *IpmiCollector) Init(config json.RawMessage) error {
 	}
 	m.ipmitool = ""
 	cclog.ComponentDebugf(m.name, "Unable to use ipmitool for ipmistat collector: %v", ipmiToolErr)
-
-	// read metrics to include
-	m.includeMetrics = make(map[string]bool)
-	for _, metric := range m.config.IncludeMetrics {
-		metric = strings.ToLower(strings.TrimSpace(metric))
-		if metric != "" {
-			m.includeMetrics[metric] = true
-		}
-	}
 
 	return fmt.Errorf("unable to init neither ipmitool (%w) nor ipmi-sensors (%w)", ipmiToolErr, ipmiSensorsErr)
 }

--- a/collectors/ipmiMetric.go
+++ b/collectors/ipmiMetric.go
@@ -36,19 +36,7 @@ type IpmiCollector struct {
 
 	ipmitool    string
 	ipmisensors string
-}
-
-func (m *IpmiCollector) metricIncluded(name string) bool {
-    if len(m.config.IncludeMetrics) == 0 {
-        return true
-    }
-
-    for _, metric := range m.config.IncludeMetrics {
-        if metric == name {
-            return true
-        }
-    }
-    return false
+	includeMetrics map[string]bool
 }
 
 func (m *IpmiCollector) Init(config json.RawMessage) error {
@@ -120,6 +108,15 @@ func (m *IpmiCollector) Init(config json.RawMessage) error {
 	m.ipmitool = ""
 	cclog.ComponentDebugf(m.name, "Unable to use ipmitool for ipmistat collector: %v", ipmiToolErr)
 
+	// read metrics to include
+	m.includeMetrics = make(map[string]bool)
+	for _, metric := range m.config.IncludeMetrics {
+		metric = strings.ToLower(strings.TrimSpace(metric))
+		if metric != "" {
+			m.includeMetrics[metric] = true
+		}
+	}
+
 	return fmt.Errorf("unable to init neither ipmitool (%w) nor ipmi-sensors (%w)", ipmiToolErr, ipmiSensorsErr)
 }
 
@@ -160,7 +157,7 @@ func (m *IpmiCollector) readIpmiTool(output chan lp.CCMessage) error {
 		}
 		name := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(lv[0]), " ", "_"))
 
-		if !m.metricIncluded(name) {
+		if len(m.includeMetrics) > 0 && !m.includeMetrics[name] {
  			continue
 		}
 
@@ -229,7 +226,7 @@ func (m *IpmiCollector) readIpmiSensors(output chan lp.CCMessage) error {
 		}
 		name := strings.ToLower(strings.ReplaceAll(lv[1], " ", "_"))
 
-		if !m.metricIncluded(name) {
+		if len(m.includeMetrics) > 0 && !m.includeMetrics[name] {
 			continue
 		}
 

--- a/collectors/ipmiMetric.md
+++ b/collectors/ipmiMetric.md
@@ -15,7 +15,8 @@ hugo_path: docs/reference/cc-metric-collector/collectors/ipmi.md
   "ipmistat": {
     "ipmitool_path": "/path/to/ipmitool",
     "ipmisensors_path": "/path/to/ipmi-sensors",
-    "use_sudo": true
+    "use_sudo": true,
+    "include_metrics" : []
   }
 ```
 
@@ -36,3 +37,5 @@ Defaults: monitoring !log_allowed, !pam_session
 monitoring ALL = (root) NOPASSWD:/usr/bin/ipmitool sensor
 monitoring ALL = (root) NOPASSWD:/usr/sbin/ipmi-sensors --comma-separated-output --sdr-cache-recreate
 ```
+
+If `include_ipmi_metrics` contains any entry, ipmistat collector will only submit these metrics. Any other values will get discarded. 


### PR DESCRIPTION
The ipmitool sensors list command might give you many many lines with different sensors, but you might be interested only in a few of them. For example only the overall system power and memory power is important. 

This PR adds an include_metrics list to the ipmi collector. If this list contains any values, only sensors will be added which name is present in this list. If the list is empty or missing, every metric will be reported. 